### PR TITLE
Adding "selectable dates" feature - the ability to pass an arbitray array of selectable dates. All other dates are disabled.

### DIFF
--- a/docs.htm
+++ b/docs.htm
@@ -230,6 +230,22 @@ class_box_weekdays: 'datepicker--holder__weekdays'</code></pre>
 
 </section>
 
+<section class="holder" id="selectable">
+
+    <fieldset>
+        <h3><strong class="underline-highlight">Arbitrary selectable dates</strong></h3>
+        <input id="input_08" class="datepicker" type="text">
+    </fieldset>
+
+    <pre><code>$( '.datepicker' ).pickadate({
+    selectable_dates: [[2012,11,22],[2012,11,23],[2012,11,26]]
+})
+    </code></pre>
+
+    <p><code>selectable_dates</code> is an array of arbitrary selectable dates. All other are disabled.</p>
+
+</section>
+
 
 <section class="holder" id="first_day">
 
@@ -426,6 +442,10 @@ class_box_weekdays: 'datepicker--holder__weekdays'</code></pre>
     })
 
     $( '#input_07' ).pickadate()
+
+    $( '#input_08' ).pickadate({
+        selectable_dates: [[2012,11,22],[2012,11,23],[2012,11,26]]
+    })
 
 </script>
 <script type="text/javascript">

--- a/pickadate.js
+++ b/pickadate.js
@@ -140,6 +140,9 @@
                 // The maximum selectable date
                 DATE_MAX,
 
+                // An array of selectable dates, each represented by an array
+                SELECTABLE_DATES,
+
                 // The month in focus on the calendar
                 MONTH_FOCUSED,
 
@@ -213,6 +216,15 @@
                     DATE_MIN = P.getDateRange( SETTINGS.date_min )
                     DATE_MAX = P.getDateRange( SETTINGS.date_max, 1 )
 
+                    if ( SETTINGS.selectable_dates != undefined && isArray( SETTINGS.selectable_dates ) ) {
+                        SELECTABLE_DATES = [];
+                        for ( var i in SETTINGS.selectable_dates ) {
+                            var date = createDate( [ SETTINGS.selectable_dates[i][0],
+                                SETTINGS.selectable_dates[i][1] - 1,
+                                SETTINGS.selectable_dates[i][2] ] );
+                            SELECTABLE_DATES.push( date );
+                        }
+                    }
 
                     // Create a calendar object and
                     // immediately render it
@@ -348,6 +360,22 @@
                                     if ( loopDate.TIME < DATE_MIN.TIME || loopDate.TIME > DATE_MAX.TIME ) {
                                         isDateDisabled = true
                                         klassCollection.push( SETTINGS.class_day_disabled )
+                                    }
+
+                                    // If it's not one of the arbitrary selectable dates.
+                                    if ( isArray( SELECTABLE_DATES ) ) {
+                                        var dateIsInArray = false;
+
+                                        $.each( SELECTABLE_DATES, function( index, selectableDate ) {
+                                           if ( selectableDate.TIME == loopDate.TIME ) {
+                                               dateIsInArray = true;
+                                           }
+                                        });
+                                        // Date is not in the array - disable it.
+                                        if ( !dateIsInArray ) {
+                                            isDateDisabled = true
+                                            klassCollection.push( SETTINGS.class_day_disabled )
+                                        }
                                     }
 
 


### PR DESCRIPTION
Simply pass an array of dates. All other dates are disabled. Good for when ranges are not enough, example: not being able to select weekends.
