### PR TITLE
Fix typos in Swedish weekdays translation

### DIFF
--- a/translations/pickadate.sv_SE.js
+++ b/translations/pickadate.sv_SE.js
@@ -3,7 +3,7 @@
 $.extend( $.fn.pickadate.defaults, {
     monthsFull: [ 'januari', 'februari', 'mars', 'april', 'maj', 'juni', 'juli', 'augusti', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
-    weekdaysFull: [ 'söödag', 'måndag', 'tisdag', 'onsdag', 'torsdag', 'fredag', 'lö̈ödag' ],
+    weekdaysFull: [ 'söndag', 'måndag', 'tisdag', 'onsdag', 'torsdag', 'fredag', 'lördag' ],
     weekdaysShort: [ 'sön', 'mån', 'tis', 'ons', 'tor', 'fre', 'lör' ],
     firstDay: 1,
     format: 'd/m yyyy',


### PR DESCRIPTION
Removed double umlauts in Swedish translation.
