### PR TITLE
Fixing f5 when the datepicker is open

### DIFF
--- a/source/pickadate.js
+++ b/source/pickadate.js
@@ -85,6 +85,8 @@
                                         P.open()
                                     }
                                 }
+                                if ( keycode == 116 )
+                                   P.close()
                             }
                         }).after( [ $HOLDER, ELEMENT_HIDDEN ] )
 


### PR DESCRIPTION
Allows an F5 refresh when the datepicker is open.
Needs to be added into every pickadate js file, only commit one since it's a very simple fix.
