### PR TITLE
Add 2000 to 2-digit year when building date

### DIFF
--- a/source/pickadate.js
+++ b/source/pickadate.js
@@ -624,7 +624,8 @@
 
                         // Finally, create an array with the date entered while
                         // parsing each item as an integer and compensating for 0index
-                        dateEntered = [ +(dateEntered.yyyy || dateEntered.yy), +(dateEntered.mm || dateEntered.m) - 1, +(dateEntered.dd || dateEntered.d) ]
+                        var year = dateEntered.yyyy || 2000 + parseInt(dateEntered.yy, 10);
+                        dateEntered = [ +(year), +(dateEntered.mm || dateEntered.m) - 1, +(dateEntered.dd || dateEntered.d) ]
                     }
 
 


### PR DESCRIPTION
The code that builds date array takes `yyyy || yy` but when there's `yy` present we should add 2000 to it first.
