### PR TITLE
Added hiddenIdSuffix option and id to hidden element

### DIFF
--- a/source/pickadate.js
+++ b/source/pickadate.js
@@ -654,7 +654,7 @@
                 // If there's a format for the hidden input element, create the element
                 // using the name of the original input plus suffix and update the value
                 // with whatever is entered in the input on load. Otherwise set it to null.
-                ELEMENT_HIDDEN = SETTINGS.formatSubmit ? $( '<input type=hidden name=' + ELEMENT.name + SETTINGS.hiddenSuffix + '>' ).val( ELEMENT.value ? getDateFormatted( SETTINGS.formatSubmit ) : '' )[ 0 ] : null,
+                ELEMENT_HIDDEN = SETTINGS.formatSubmit ? $( '<input type=hidden id=' + SETTINGS.hiddenIdSuffix + ' name=' + ELEMENT.name + SETTINGS.hiddenSuffix + '>' ).val( ELEMENT.value ? getDateFormatted( SETTINGS.formatSubmit ) : '' )[ 0 ] : null,
 
 
                 // Create the calendar table head with weekday labels
@@ -1572,6 +1572,9 @@
 
         // Hidden element name suffix
         hiddenSuffix: '_submit',
+
+        // Hidden element id suffix
+        hiddenIdSuffix: '_ident',
 
         // First day of the week: 0 = Sunday, 1 = Monday
         firstDay: 0,

--- a/source/pickadate.legacy.js
+++ b/source/pickadate.legacy.js
@@ -654,7 +654,7 @@
                 // If there's a format for the hidden input element, create the element
                 // using the name of the original input plus suffix and update the value
                 // with whatever is entered in the input on load. Otherwise set it to null.
-                ELEMENT_HIDDEN = SETTINGS.formatSubmit ? $( '<input type=hidden name=' + ELEMENT.name + SETTINGS.hiddenSuffix + '>' ).val( ELEMENT.value ? getDateFormatted( SETTINGS.formatSubmit ) : '' )[ 0 ] : null,
+                ELEMENT_HIDDEN = SETTINGS.formatSubmit ? $( '<input type=hidden id=' + SETTINGS.hiddenIdSuffix + ' name=' + ELEMENT.name + SETTINGS.hiddenSuffix + '>' ).val( ELEMENT.value ? getDateFormatted( SETTINGS.formatSubmit ) : '' )[ 0 ] : null,
 
 
                 // Create the calendar table head with weekday labels
@@ -1572,6 +1572,9 @@
 
         // Hidden element name suffix
         hiddenSuffix: '_submit',
+
+        // Hidden element id suffix
+        hiddenIdSuffix: '_ident',
 
         // First day of the week: 0 = Sunday, 1 = Monday
         firstDay: 0,


### PR DESCRIPTION
Using this wonderful project at work. Our coding standards dictate using the id attribute rather then the name attribute as jQuery selectors. Mostly a semantical issue but figured others might like this as well. Did not update docs/change log. Can do if you'd like to integrate the change into the main branch. 
