### PR TITLE
Update pickadate.sv_SE.js

### DIFF
--- a/translations/pickadate.sv_SE.js
+++ b/translations/pickadate.sv_SE.js
@@ -5,9 +5,9 @@ $.extend( $.fn.pickadate.defaults, {
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'söndag', 'måndag', 'tisdag', 'onsdag', 'torsdag', 'fredag', 'lördag' ],
     weekdaysShort: [ 'sön', 'mån', 'tis', 'ons', 'tor', 'fre', 'lör' ],
-    today: 'i dag',
-    clear: 'bort',
+    today: 'idag',
+    clear: 'rensa',
     firstDay: 1,
-    format: 'd/m yyyy',
-    formatSubmit: 'yyyy/mm/dd'
+    format: 'd mmmmm yyyy',
+    formatSubmit: 'yyyy-mm-dd'
 })


### PR DESCRIPTION
Edited to comply with the date formats actually used in Sweden, also the proper translation for "today" and "clear"
