### PR TITLE
Fixes library so it works with jQuery 1.7

### DIFF
--- a/source/pickadate.js
+++ b/source/pickadate.js
@@ -120,7 +120,7 @@
                                     }
                                 }
                             }
-                        }).after( [ $HOLDER, ELEMENT_HIDDEN ] )
+                        }).after( $HOLDER, ELEMENT_HIDDEN )
 
 
                         // If the element has autofocus, open the calendar

--- a/source/pickadate.legacy.js
+++ b/source/pickadate.legacy.js
@@ -120,7 +120,7 @@
                                     }
                                 }
                             }
-                        }).after( [ $HOLDER, ELEMENT_HIDDEN ] )
+                        }).after( $HOLDER, ELEMENT_HIDDEN )
 
 
                         // If the element has autofocus, open the calendar


### PR DESCRIPTION
If you try to use the plugin with jQuery 1.7 (1.7.1, 1.7.2) it will throw an exception  `Uncaught Error: NotFoundError: DOM Exception 8.`.
