### PR TITLE
Add Bower 'main' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "pickadate",
     "version": "2.1.8",
     "title": "pickadate.js",
+    "main": "source/pickadate.js",
     "author": {
         "name" : "Amsul",
         "email" : "reach@amsul.ca",


### PR DESCRIPTION
This repo has been added to bower, but fails to install since bower can't find the main javascript file.

```
Fatal error: Bower: can’t detect main file for "pickadate" component.You should add it manually to concat task and exclude from bower task build.
```
