### PR TITLE
Change the way elements are given focus.

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -91,11 +91,11 @@ function DatePicker( picker, settings ) {
         on( 'render', function() {
             picker.$root.find( '.' + settings.klass.selectMonth ).on( 'change', function() {
                 picker.set( 'highlight', [ picker.get( 'view' ).year, this.value, picker.get( 'highlight' ).date ] )
-                picker.$root.find( '.' + settings.klass.selectMonth ).focus()
+                picker.$root.find( '.' + settings.klass.selectMonth ).trigger( 'focus' )
             })
             picker.$root.find( '.' + settings.klass.selectYear ).on( 'change', function() {
                 picker.set( 'highlight', [ this.value, picker.get( 'view' ).month, picker.get( 'highlight' ).date ] )
-                picker.$root.find( '.' + settings.klass.selectYear ).focus()
+                picker.$root.find( '.' + settings.klass.selectYear ).trigger( 'focus' )
             })
         }).
         on( 'open', function() {

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -122,7 +122,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                             // If nothing inside is actively focused, re-focus the element.
                             if ( !P.$root.find( document.activeElement ).length ) {
-                                ELEMENT.focus()
+                                ELEMENT.trigger( 'focus' )
                             }
 
                             // If something is superficially changed, update the `highlight` based on the `nav`.
@@ -301,7 +301,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     STATE.open = true
 
                     // Pass focus to the element’s jQuery object.
-                    $ELEMENT.focus()
+                    $ELEMENT.trigger( 'focus' )
 
                     // Bind the document events.
                     $document.on( 'click.P' + STATE.id + ' focusin.P' + STATE.id, function( event ) {
@@ -373,7 +373,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     // ....ah yes! It would’ve been incomplete without a crazy workaround for IE :|
                     // The focus is triggered *after* the close has completed - causing it
                     // to open again. So unbind and rebind the event at the next tick.
-                    $ELEMENT.off( 'focus.P' + STATE.id ).focus()
+                    $ELEMENT.off( 'focus.P' + STATE.id ).trigger( 'focus' )
                     setTimeout( function() {
                         $ELEMENT.on( 'focus.P' + STATE.id, focusToOpen )
                     }, 0 )


### PR DESCRIPTION
I know this might very much be an edge case, but I'm currently trying to use a custom build of jQuery without the `event-alias` module (among others), and that drops the `focus` method, so changing to `trigger( 'focus' )` solves that issue.

It's a non-destructive change that will make the lives of a few of us (picky) devs a little bit easier :)
