### PR TITLE
Translations link fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ __*__ One and only one base stylesheet is **required**. [Choose a theme](http://
 
 ### Translations
 
-The translations are copied into the `lib/translations` folder. There are currently [30 languages](https://github.com/amsul/pickadate.js/blob/v3.0.5/lib/translations) included.
+The translations are copied into the `lib/translations` folder. There are currently [30 languages](https://github.com/amsul/pickadate.js/tree/gh-pages/lib/translations) included.
 
 
 


### PR DESCRIPTION
In README.md the link to the translations was broken, now the link works good. 
I've read the guidelines but the fix is on gh-pages branch, not the dev branch.
