### PR TITLE
Allow reseting disabled dates

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1,4 +1,3 @@
-
 /*!
  * Date picker for pickadate.js v3.1.0
  * http://amsul.github.io/pickadate.js/date.htm
@@ -600,11 +599,19 @@ DatePicker.prototype.flipItem = function( type, value/*, options*/ ) {
  */
 DatePicker.prototype.addDisabled = function( collection, item ) {
     var calendar = this
-    item.map( function( timeUnit ) {
-        if ( !calendar.filterDisabled( collection, timeUnit ).length ) {
-            collection.push( timeUnit )
-        }
-    })
+
+    if ( item ) {
+      item.map( function( timeUnit ) {
+          if ( !calendar.filterDisabled( collection, timeUnit ).length ) {
+              collection.push( timeUnit )
+          }
+      })
+    }
+
+    else {
+      collection = []
+    }
+
     return collection
 } //DatePicker.prototype.addDisabled
 


### PR DESCRIPTION
There was no way to reset all disabled dates, now you can:

``` javascript
this.get('picker').set('disable', undefined);
```
