### PR TITLE
time picker steals focus and clears input on pressing enter in another form input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickadate",
-  "version": "3.2.2",
+  "version": "3.2.1",
   "title": "pickadate.js",
   "description": "The mobile-friendly, responsive, and lightweight jQuery date & time input picker.",
   "author": {


### PR DESCRIPTION
Reproduced here:
http://jsfiddle.net/2pspY/8/

Steps to reproduce:

have 3 input elements: one for date, one for time, one other input field
1. Pick a date
2. Pick a time
3. Type something in the other element if desired
4. Press enter key while focus is on the other element

Browser: Chrome version 29.0.1547.65
OS: OS X 10.8.3
Pickadate.js: version 3.2.1
