### PR TITLE
When the picker is in a modal popup like MagnificPopup, the click handler on document are in conflict on Chrome/Linux.

### DIFF
--- a/_raw/lib/picker.js
+++ b/_raw/lib/picker.js
@@ -112,6 +112,10 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                         // If the click is not on the root holder, stop it from bubbling to the doc.
                         'mousedown click': function( event ) {
+                            // For select and option elements, we allow them to keep there original behaior
+                            if ( $(event.target).not('select, option').length > 0 ) {
+                                event.preventDefault()
+                            }
                             if ( event.target != P.$root.children()[ 0 ] ) {
                                 event.stopPropagation()
                             }
@@ -119,7 +123,9 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     }).
 
                     // If there’s a click on an actionable element, carry out the actions.
-                    on( 'click', '[data-pick], [data-nav], [data-clear]', function() {
+                    on( 'click', '[data-pick], [data-nav], [data-clear]', function(event) {
+                        event.preventDefault()
+                        event.stopPropagation()
 
                         var $target = $( this ),
                             targetData = $target.data(),

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -1,6 +1,6 @@
 
 /*!
- * pickadate.js v3.3.0, 2013/10/13
+ * pickadate.js v3.3.0, 2013/10/15
  * By Amsul, http://amsul.ca
  * Hosted on http://amsul.github.io/pickadate.js
  * Licensed under MIT
@@ -112,6 +112,10 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                         // If the click is not on the root holder, stop it from bubbling to the doc.
                         'mousedown click': function( event ) {
+                            // For select and option elements, we allow them to keep there original behaior
+                            if ( $(event.target).not('select, option').length > 0 ) {
+                                event.preventDefault()
+                            }
                             if ( event.target != P.$root.children()[ 0 ] ) {
                                 event.stopPropagation()
                             }
@@ -119,7 +123,9 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     }).
 
                     // If there’s a click on an actionable element, carry out the actions.
-                    on( 'click', '[data-pick], [data-nav], [data-clear]', function() {
+                    on( 'click', '[data-pick], [data-nav], [data-clear]', function(event) {
+                        event.preventDefault()
+                        event.stopPropagation()
 
                         var $target = $( this ),
                             targetData = $target.data(),


### PR DESCRIPTION
On Chrome/Linux, when the date picker is in a modal like MagnificPopup (http://dimsemenov.com/plugins/magnific-popup/), two events handler on $document for click are in conflict.

The method event.stopPropagation() in P.$root.on('click') is not sufficient, we have to prevent default behavior too with event.preventDefault().
