### PR TITLE
Configurable readonly.

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -933,6 +933,8 @@ DatePicker.prototype.nodes = function( isOpen ) {
 DatePicker.defaults = (function( prefix ) {
 
     return {
+        // Mark input as readonly
+        readOnly: true,
 
         // Months and weekdays
         monthsFull: [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ],

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -92,7 +92,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 // and set as readonly to prevent keyboard popup.
                 ELEMENT.autofocus = ELEMENT == document.activeElement
                 ELEMENT.type = 'text'
-                ELEMENT.readOnly = true
+                ELEMENT.readOnly = SETTINGS.readOnly
 
 
                 // Create a new picker component with the settings.

--- a/lib/picker.time.js
+++ b/lib/picker.time.js
@@ -638,6 +638,8 @@ TimePicker.prototype.nodes = function( isOpen ) {
 TimePicker.defaults = (function( prefix ) {
 
     return {
+        // Mark input as readonly
+        readOnly: true,
 
         // Clear
         clear: 'Clear',


### PR DESCRIPTION
Marking the input as readonly without any way to disable this behavior is a little frustrating. This makes it configurable.
