### PR TITLE
Fix Drop Down Selector Font Size

### DIFF
--- a/lib/themes/classic.date.css
+++ b/lib/themes/classic.date.css
@@ -35,7 +35,7 @@
  */
 .picker__select--month,
 .picker__select--year {
-  font-size: .8em;
+  font-size: .6em;
   border: 1px solid #b7b7b7;
   height: 2.5em;
   padding: .5em .25em;


### PR DESCRIPTION
Month and Year drop down selectors had the font size set too high. This was causing portions of the month and year names to render underneath the selector's chrome. Making the fonts slightly smaller resolves the issue.
## Before Fix

![before-fix](https://f.cloud.github.com/assets/3300/1563404/ab20c6d8-505f-11e3-9f99-c30149974f74.png)
## After Fix

![after-fix](https://f.cloud.github.com/assets/3300/1563409/b6492e6a-505f-11e3-9ecc-70ba18120306.png)
