### PR TITLE
Fix Drop Down Selector Font Size

### DIFF
--- a/lib/themes/classic.date.css
+++ b/lib/themes/classic.date.css
@@ -35,7 +35,7 @@
  */
 .picker__select--month,
 .picker__select--year {
-  font-size: .8em;
+  font-size: .6em;
   border: 1px solid #b7b7b7;
   height: 2.5em;
   padding: .5em .25em;


### PR DESCRIPTION
Month and Year drop down selectors had the font size set too high. This was causing portions of the month and year names to render underneath the selector's chrome. Making the fonts slightly smaller resolves the issue. Please see the associated ticket for this change to see before and after screen captures.
## Before Fix

![ab20c6d8-505f-11e3-9f99-c30149974f74](https://f.cloud.github.com/assets/3300/1613535/dd376e94-55da-11e3-9f49-fac83bda90f0.png)
## After Fix

![b6492e6a-505f-11e3-9ecc-70ba18120306](https://f.cloud.github.com/assets/3300/1613540/e5e1b298-55da-11e3-94fe-133d36611022.png)
