### PR TITLE
Add highlightWeekends option to Date picker

### DIFF
--- a/_raw/date.htm
+++ b/_raw/date.htm
@@ -59,6 +59,9 @@ selectMonths: undefined,
 // <a href="#first-weekday">First day of the week</a>
 firstDay: undefined,
 
+// <a href="#highlight-weekends">Highlight weekends</a>
+highlightWeekends: undefined,
+
 // <a href="#limits">Date limits</a>
 min: undefined,
 max: undefined,
@@ -373,6 +376,24 @@ $('.datepicker').pickadate({
 })</code></pre>
 
         {%= dateDemoField({ id: 'date_demo__firstDay' }) %}
+
+    </div> <!-- .section__block -->
+
+</section> <!-- .section -->
+
+
+<section class="section">
+
+    <div class="section__block section__block--scoped">
+
+        <h2 class="heading heading--divide"><span class="heading__text">Highlight Weekends<a class="heading__anchor" name="highlight-weekends" href="#highlight-weekends">&sect;</a></span></h2>
+        <p>Highlight Saturdays and Sundays:</p>
+
+        <pre class="pre--demo"><code data-language="javascript">$('.datepicker').pickadate({
+            highlightWeekends: true
+            })</code></pre>
+
+        {%= dateDemoField({ id: 'date_demo__highlightWeekends' }) %}
 
     </div> <!-- .section__block -->
 

--- a/_raw/demo/scripts/base.js
+++ b/_raw/demo/scripts/base.js
@@ -125,6 +125,13 @@ $( '#date_demo__firstDay' ).pickadate({
 })
 
 
+/**
+ * Highlight weekends
+ */
+$( '#date_demo__highlightWeekends' ).pickadate({
+    highlightWeekends: true
+})
+
 
 /**
  * Limits

--- a/_raw/lib/picker.date.js
+++ b/_raw/lib/picker.date.js
@@ -896,6 +896,10 @@ DatePicker.prototype.nodes = function( isOpen ) {
                                                 klasses.push( settings.klass.highlighted )
                                             }
 
+                                            if ( settings.highlightWeekends && (!targetDate.day || targetDate.day === 6)){
+                                                klasses.push( settings.klass.weekend )
+                                            }
+
                                             // Add the `disabled` class if something's disabled and the object matches.
                                             if ( disabledCollection && calendar.disabled( targetDate ) || targetDate.pick < minLimitObject.pick || targetDate.pick > maxLimitObject.pick ) {
                                                 klasses.push( settings.klass.disabled )
@@ -973,6 +977,7 @@ DatePicker.defaults = (function( prefix ) {
             now: prefix + 'day--today',
             infocus: prefix + 'day--infocus',
             outfocus: prefix + 'day--outfocus',
+            weekend: prefix + 'day--weekend',
 
             footer: prefix + 'footer',
 

--- a/_raw/lib/themes/_variables.less
+++ b/_raw/lib/themes/_variables.less
@@ -11,6 +11,7 @@
 @blue-hover: #b1dcfb;
 @black: #000;
 @white: #fff;
+@red: #e20;
 
 
 //

--- a/_raw/lib/themes/base.date.less
+++ b/_raw/lib/themes/base.date.less
@@ -236,6 +236,11 @@
     background: @disabled-highlighted-things-bg;
 }
 
+// Weekend or holiday items.
+.picker__day--weekend  {
+    color:@red;
+}
+
 
 /**
  * The footer containing the "today" and "clear" buttons.

--- a/tests/units/date.js
+++ b/tests/units/date.js
@@ -360,8 +360,7 @@ test( '`max`', function() {
     deepEqual( picker.get( 'select' ), picker.get( 'now' ), '`select` unaffected' )
     deepEqual( picker.get( 'highlight' ), picker.get( 'select' ), '`highlight` unaffected' )
 
-    playdate.setMonth( today.getMonth() )
-    playdate.setDate( 1 )
+    playdate = new Date( today.getFullYear(), today.getMonth(), 1 )
     deepEqual( picker.get( 'view' ).obj, playdate, '`view` unaffected' )
     strictEqual( picker.get( 'value' ), '', '`value` unaffected' )
     deepEqual( picker.get( 'min' ).pick, -Infinity, '`min` unaffected' )


### PR DESCRIPTION
Hi! 

I've added highlightWeekends option to Date picker. 
It's quite simple but useful (at least for me). Just highlights Sundays and Saturdays with red. 

I'm also thinking of the following feature - highlightHolidays, which depends on localization. What do you think about it?  


P.S. Also fixed one test.