### PR TITLE
Typo fix and lowercase needed

### DIFF
--- a/lib/translations/es_ES.js
+++ b/lib/translations/es_ES.js
@@ -1,8 +1,8 @@
 // Spanish
 
 jQuery.extend( jQuery.fn.pickadate.defaults, {
-    monthsFull: [ 'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre' ],
-    monthsShort: [ 'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic' ],
+    monthsFull: [ 'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre' ],
+    monthsShort: [ 'ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic' ],
     weekdaysFull: [ 'domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado' ],
     weekdaysShort: [ 'dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb' ],
     today: 'hoy',


### PR DESCRIPTION
“sab” comes from “sábado” so it should be “sáb” instead.
Although I’m not completely sure if “tildes” should be used, either you use them on both "sáb" and "mié" or you don’t.

Also, the days of the week as well as month names should be in lowercase (for exceptions check http://lema.rae.es/dpd/srv/search?id=BapzSnotjD6n0vZiTp - in Spanish only)
