### PR TITLE
fix bug, when formatSubmit was improperly appending suffixes

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -676,7 +676,17 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
         var id = [
             typeof SETTINGS.hiddenPrefix == 'string' ? SETTINGS.hiddenPrefix : '',
             typeof SETTINGS.hiddenSuffix == 'string' ? SETTINGS.hiddenSuffix : '_submit'
-        ]
+        ],
+        name = ELEMENT.name,
+        n, name_and_suffix;
+
+        //if last character of name is "]"
+        if(name[name.length - 1] === "]"){
+            n = name.lastIndexOf("]")
+            name_and_suffix = name.substring(0, n) + id[1] + name.substring(n)
+        } else {
+            name_and_suffix = name + id[1]
+        }
 
         P._hidden = $(
             '<input ' +
@@ -684,7 +694,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
             // Create the name and ID by using the original
             // input’s with a prefix and suffix.
-            'name="' + id[0] + ELEMENT.name + id[1] + '"' +
+            'name="' + id[0] + name_and_suffix + '"' +
             'id="' + id[0] + ELEMENT.id + id[1] + '"' +
 
             // If the element has a value, set the hidden value as well.


### PR DESCRIPTION
* for example a name like `order[date]` would incorrectly be changed
to `order[date]_submit`
* in this example, the input should have the name `order[date_submit]`