### PR TITLE
Fix typos in Hungarian translation

### DIFF
--- a/lib/translations/hu_HU.js
+++ b/lib/translations/hu_HU.js
@@ -1,12 +1,12 @@
 // Hungarian
 
 jQuery.extend( jQuery.fn.pickadate.defaults, {
-    monthsFull: [ 'január', 'február', 'március', 'aprilis', 'május', 'június', 'július', 'augusztus', 'szeptember', 'október', 'november', 'december' ],
-    monthsShort: [ 'jan', 'febr', 'márc', 'apr', 'máj', 'jún', 'júl', 'aug', 'szept', 'okt', 'nov', 'dec' ],
-    weekdaysFull: [ 'vasámap', 'hétfö', 'kedd', 'szerda', 'csütörtök', 'péntek', 'szombat' ],
-    weekdaysShort: [ 'V', 'H', 'K', 'SZ', 'CS', 'P', 'SZ' ],
-    today: 'ma',
-    clear: 'töröl',
+    monthsFull: [ 'január', 'február', 'március', 'április', 'május', 'június', 'július', 'augusztus', 'szeptember', 'október', 'november', 'december' ],
+    monthsShort: [ 'jan', 'febr', 'márc', 'ápr', 'máj', 'jún', 'júl', 'aug', 'szept', 'okt', 'nov', 'dec' ],
+    weekdaysFull: [ 'vasárnap', 'hétfő', 'kedd', 'szerda', 'csütörtök', 'péntek', 'szombat' ],
+    weekdaysShort: [ 'V', 'H', 'K', 'SZe', 'CS', 'P', 'SZo' ],
+    today: 'Ma',
+    clear: 'Törlés',
     firstDay: 1,
     format: 'yyyy. mmmm dd.',
     formatSubmit: 'yyyy/mm/dd'


### PR DESCRIPTION
Some words in the translation were mistyped like "vasámap" which should be "vasárnap" (means Sunday).
