### PR TITLE
Corrected behavior when both value and data-value attributes are set

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1,4 +1,3 @@
-
 /*!
  * Date picker for pickadate.js v3.4.0
  * http://amsul.github.io/pickadate.js/date.htm
@@ -72,7 +71,7 @@ function DatePicker( picker, settings ) {
     if ( valueString ) {
         calendar.set( 'select', valueString, {
             format: formatString,
-            fromValue: !!elementValue
+            fromValue: !elementDataValue
         })
     }
 
@@ -579,7 +578,7 @@ DatePicker.prototype.parse = function( type, value, options ) {
     }
 
     // Calculate the month index to adjust with.
-    monthIndex = typeof value == 'string' && !options.fromValue ? 1 : 0
+    monthIndex = typeof value == 'string' && !options.fromValue ? 1 : 0
 
     // Convert the format into an array and then map through it.
     calendar.formats.toArray( options.format ).map( function( label ) {


### PR DESCRIPTION
1. removed invalid character in line 581
2. changed determination of 'fromValue' flag on init.

When having a node like this:

```
 <input value="2014-04-10" data-value="2014-04-10" />
```

And initializing pickadate like: 

```
 $("input").pickadate( {formatSubmit: "yyyy-mm-dd"});
```

The _expected_ behaviour is to set the date to April 10, 2014. 

The previous implementation took the value from data-value but determined the fromValue flag by evaluating !!elementValue. This means, as long as value-attribute is set, the data-value attribute is treated with zero-based month-index, so the date would be set to March 10, 2014.
