### PR TITLE
getScrollbarWidth check scrollbar is visible first

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -829,7 +829,11 @@ function isUsingDefaultTheme( element ) {
  * Taken from: https://github.com/VodkaBears/Remodal/blob/master/src/jquery.remodal.js
  */
 function getScrollbarWidth() {
-
+    
+    // Is the scrollbar visible
+    if($(document).height() <= $(window).height())
+        return 0;
+        
     var $outer = $( '<div style="visibility:hidden;width:100px" />' ).
         appendTo( 'body' )
 


### PR DESCRIPTION
The padding adjustment is applied regardless of whether the scrollbars are visible or not.
Check if document height is less than or equal to window height meaning scrollbars are hidden.
I think there is probably a better fix than having to compensate for the scrollbars at all.
Tested in chrome and safari. Not tested in IE.
Resolves #404.
