### PR TITLE
Explicitly define ignore files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickadate",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "title": "pickadate.js",
   "description": "The mobile-friendly, responsive, and lightweight jQuery date & time input picker.",
   "author": {
@@ -22,8 +22,12 @@
     "responsive"
   ],
   "ignore": [
-    "*",
-    "!lib/**/*"
+    "*.md",
+    "*.htm",
+    "_docs",
+    "demo",
+    "tests",
+    "v2-(deprecated)"
   ],
   "main": "lib/picker.js",
   "homepage": "http://amsul.github.io/pickadate.js",


### PR DESCRIPTION
https://github.com/amsul/pickadate.js/issues/432

Bower is installing a blank folder for pickadate in some environments
(Heroku), which appears to be related to the way in which the `ignore`
section of the package manifest is defined. It's not clear from the
bower documentation how conflicts might be resolved (for example, \* and
"not lib" would still ignore lib, which is what's happening in my
environment now, lib is never being downloaded).

Removed the `*` declaration and explicitly defined paths to ignore in
the `ignore` section of `package.json`.
