### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,11 @@
     "tests",
     "v2-(deprecated)"
   ],
-  "main": "lib/picker.js",
+  "main": [
+    "lib/picker.js"
+    "lib/picker.date.js",
+    "lib/picker.time.js"
+  ],
   "homepage": "http://amsul.github.io/pickadate.js",
   "docs": "http://amsul.github.io/pickadate.js",
   "demo": "http://amsul.github.io/pickadate.js",


### PR DESCRIPTION
This is a more accurate representation for bower.  Myself and many others use wiredep to automatically inject script references and your plugin doesn't work well with this because it doesn't include all main files.  This update should fix that.
