### PR TITLE
Italian translation file improvements

### DIFF
--- a/lib/translations/it_IT.js
+++ b/lib/translations/it_IT.js
@@ -1,14 +1,24 @@
 // Italian
 
 jQuery.extend( jQuery.fn.pickadate.defaults, {
+    labelMonthNext: 'Mese successivo',
+    labelMonthPrev: 'Mese precedente',
+    labelMonthSelect: 'Seleziona un mese',
+    labelYearSelect: 'Seleziona un anno',
     monthsFull: [ 'gennaio', 'febbraio', 'marzo', 'aprile', 'maggio', 'giugno', 'luglio', 'agosto', 'settembre', 'ottobre', 'novembre', 'dicembre' ],
     monthsShort: [ 'gen', 'feb', 'mar', 'apr', 'mag', 'giu', 'lug', 'ago', 'set', 'ott', 'nov', 'dic' ],
-    weekdaysFull: [ 'domenica', 'lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato' ],
+    weekdaysFull: [ 'domenica', 'lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato' ],
     weekdaysShort: [ 'dom', 'lun', 'mar', 'mer', 'gio', 'ven', 'sab' ],
     today: 'Oggi',
-    clear: 'Cancellare',
+    clear: 'Cancella',
     close: 'Chiudi',
     firstDay: 1,
     format: 'dddd d mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
+});
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Cancella',
+    format: 'HH:i',
+    formatSubmit: 'HH:i'
 });


### PR DESCRIPTION
## Improvements:
- Fixed accents
- Added missing Pickadate translations
- Added missing Pickatime translations
## Note:

1- No translations for Pickatime in any language
2- Except Italian, only fr_FR and hi_IN have translations for this labels:

```
labelMonthNext
labelMonthPrev
labelMonthSelect
labelYearSelect
```
