### PR TITLE
* Add translations for pickatime object

### DIFF
--- a/lib/translations/ar.js
+++ b/lib/translations/ar.js
@@ -10,3 +10,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy mmmm dd',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'مسح'
+});

--- a/lib/translations/bg_BG.js
+++ b/lib/translations/bg_BG.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy г.',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'изтривам'
+});

--- a/lib/translations/bs_BA.js
+++ b/lib/translations/bs_BA.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd. mmmm yyyy.',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'izbrisati'
+});

--- a/lib/translations/ca_ES.js
+++ b/lib/translations/ca_ES.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd d !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'esborrar'
+});

--- a/lib/translations/cs_CZ.js
+++ b/lib/translations/cs_CZ.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'vymazat'
+});

--- a/lib/translations/da_DK.js
+++ b/lib/translations/da_DK.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'slet'
+});

--- a/lib/translations/de_DE.js
+++ b/lib/translations/de_DE.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd, dd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Löschen'
+});

--- a/lib/translations/el_GR.js
+++ b/lib/translations/el_GR.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Διαγραφή'
+});

--- a/lib/translations/es_ES.js
+++ b/lib/translations/es_ES.js
@@ -12,3 +12,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd d !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'borrar'
+});

--- a/lib/translations/et_EE.js
+++ b/lib/translations/et_EE.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy. a',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'kustutama'
+});

--- a/lib/translations/eu_ES.js
+++ b/lib/translations/eu_ES.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd, yyyy(e)ko mmmmren da',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'garbitu'
+});

--- a/lib/translations/fi_FI.js
+++ b/lib/translations/fi_FI.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd.m.yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'tyhjennä'
+});

--- a/lib/translations/fr_FR.js
+++ b/lib/translations/fr_FR.js
@@ -16,3 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelMonthSelect: 'Sélectionner un mois',
     labelYearSelect: 'Sélectionner une année'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Effacer'
+});

--- a/lib/translations/gl_ES.js
+++ b/lib/translations/gl_ES.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd d !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'borrar'
+});

--- a/lib/translations/he_IL.js
+++ b/lib/translations/he_IL.js
@@ -10,3 +10,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy mmmmב d dddd',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'למחוק'
+});

--- a/lib/translations/hi_IN.js
+++ b/lib/translations/hi_IN.js
@@ -14,3 +14,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelMonthSelect: 'किसि एक महीने का चयन करें',
     labelYearSelect: 'किसि एक वर्ष का चयन करें'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'चुनी हुई तारीख को मिटाएँ'
+});

--- a/lib/translations/hr_HR.js
+++ b/lib/translations/hr_HR.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy.',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'izbrisati'
+});

--- a/lib/translations/hu_HU.js
+++ b/lib/translations/hu_HU.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy. mmmm dd.',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Törlés'
+});

--- a/lib/translations/id_ID.js
+++ b/lib/translations/id_ID.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'menghapus'
+});

--- a/lib/translations/is_IS.js
+++ b/lib/translations/is_IS.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Hreinsa'
+});

--- a/lib/translations/it_IT.js
+++ b/lib/translations/it_IT.js
@@ -12,3 +12,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd d mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Cancellare'
+});

--- a/lib/translations/ja_JP.js
+++ b/lib/translations/ja_JP.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy mm dd',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: '消去'
+});

--- a/lib/translations/ko_KR.js
+++ b/lib/translations/ko_KR.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy 년 mm 월 dd 일',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: '취소'
+});

--- a/lib/translations/ne_NP.js
+++ b/lib/translations/ne_NP.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd, dd mmmm, yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'मेटाउनुहोस्'
+});

--- a/lib/translations/nl_NL.js
+++ b/lib/translations/nl_NL.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd d mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'verwijderen'
+});

--- a/lib/translations/no_NO.js
+++ b/lib/translations/no_NO.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd. mmm. yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'nullstill'
+});

--- a/lib/translations/pl_PL.js
+++ b/lib/translations/pl_PL.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'usunąć'
+});

--- a/lib/translations/pt_BR.js
+++ b/lib/translations/pt_BR.js
@@ -10,3 +10,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd, d !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'excluir'
+});

--- a/lib/translations/pt_PT.js
+++ b/lib/translations/pt_PT.js
@@ -10,3 +10,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'excluir'
+});

--- a/lib/translations/ro_RO.js
+++ b/lib/translations/ro_RO.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'șterge'
+});

--- a/lib/translations/ru_RU.js
+++ b/lib/translations/ru_RU.js
@@ -12,3 +12,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy г.',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'удалить'
+});

--- a/lib/translations/sk_SK.js
+++ b/lib/translations/sk_SK.js
@@ -12,3 +12,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'vymazať'
+});

--- a/lib/translations/sl_SI.js
+++ b/lib/translations/sl_SI.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'izbriši'
+});

--- a/lib/translations/sv_SE.js
+++ b/lib/translations/sv_SE.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd/m yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'bort'
+});

--- a/lib/translations/th_TH.js
+++ b/lib/translations/th_TH.js
@@ -10,3 +10,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'ลบ'
+});

--- a/lib/translations/tr_TR.js
+++ b/lib/translations/tr_TR.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd mmmm yyyy dddd',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'sil'
+});

--- a/lib/translations/uk_UA.js
+++ b/lib/translations/uk_UA.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd mmmm yyyy p.',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'викреслити'
+});

--- a/lib/translations/vi_VN.js
+++ b/lib/translations/vi_VN.js
@@ -9,3 +9,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     clear: 'Xoá',
     firstDay: 1
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Xoá'
+});

--- a/lib/translations/zh_CN.js
+++ b/lib/translations/zh_CN.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy 年 mm 月 dd 日',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: '删'
+});

--- a/lib/translations/zh_TW.js
+++ b/lib/translations/zh_TW.js
@@ -11,3 +11,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy 年 mm 月 dd 日',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: '清除'
+});


### PR DESCRIPTION
The "Clear" button in the pickatime object is never translated. This commit copies the "Clear" translation from the pickadate object and merges it with the pickatime defaults.
