### PR TITLE
Remove references to UTC

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -34,9 +34,9 @@ var DAYS_IN_WEEK = 7,
 var timezoneOffset = new Date().getTimezoneOffset()
 var timezoneOffsetMS = timezoneOffset * 60 * 1000
 var isLocalDateSame = function(relative, absolute) {
-    return relative.getDate() === absolute.getUTCDate() &&
-        relative.getMonth() === absolute.getUTCMonth() &&
-        relative.getFullYear() === absolute.getUTCFullYear()
+    return relative.getDate() === absolute.getDate() &&
+        relative.getMonth() === absolute.getMonth() &&
+        relative.getFullYear() === absolute.getFullYear()
 }
 var isLocalDateLessThan = function(one, two) {
     return new Date(one.year, one.month, one.date) < new Date(two.year, two.month, two.date)
@@ -1207,7 +1207,7 @@ DatePicker.prototype.nodes = function( isOpen ) {
                                 return [
                                     _.node(
                                         'div',
-                                        targetDate.obj.getUTCDate(),
+                                        targetDate.obj.getDate(),
                                         (function( klasses ) {
 
                                             // Add the `infocus` or `outfocus` classes based on month in view.


### PR DESCRIPTION
I was getting some odd behaviour when using the dev branch (as at 7a5f638) where the calendar was showing dates offset by -1 day, although picking them resulted in the correct date filling the input. To illustrate, Wednesday 21 October 2014 was showing up - impossible date - but clicking it filled the input with 22 October.

I just removed all references to UTC in picker.date.js and it seems to behave itself.
