### PR TITLE
Update pt_PT.js

### DIFF
--- a/lib/translations/pt_PT.js
+++ b/lib/translations/pt_PT.js
@@ -1,16 +1,16 @@
 // Portuguese
 
 jQuery.extend( jQuery.fn.pickadate.defaults, {
-    monthsFull: [ 'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho', 'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro' ],
+    monthsFull: [ 'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro' ],
     monthsShort: [ 'jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez' ],
-    weekdaysFull: [ 'domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado' ],
+    weekdaysFull: [ 'Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado' ],
     weekdaysShort: [ 'dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sab' ],
-    today: 'hoje',
-    clear: 'excluir',
+    today: 'Hoje',
+    clear: 'Limpar',
     format: 'd !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
 
 jQuery.extend( jQuery.fn.pickatime.defaults, {
-    clear: 'excluir'
+    clear: 'Limpar'
 });

--- a/lib/translations/pt_PT.js
+++ b/lib/translations/pt_PT.js
@@ -7,6 +7,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     weekdaysShort: [ 'dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sab' ],
     today: 'Hoje',
     clear: 'Limpar',
+    close: 'Fechar',
     format: 'd !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });


### PR DESCRIPTION
Months, weekdays and the words clear and today should be capitalized in Portuguese. Also, the previous translation for "clear" was not too accurate.