### PR TITLE
Fix for fields wrapped in a label

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -338,6 +338,15 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                         P.$root.on( 'focus.toOpen', handleFocusToOpenEvent )
                     }, 0 )
                 }
+                
+                // If the element lives inside a label, temporarily remove click event to avoid
+                // it to re-open, as clicking on the label would focus on the element again.
+                if ( $ELEMENT.parents('label').length > 0 ) {
+                    $ELEMENT.off('click.' + STATE.id)
+                    setTimeout(function () {
+                        $ELEMENT.on('click.' + STATE.id, focusToOpen)
+                    }, 0)
+                }
 
                 // Remove the “active” class.
                 $ELEMENT.removeClass( CLASSES.active )


### PR DESCRIPTION
relates to:
https://github.com/amsul/pickadate.js/issues/40
https://github.com/amsul/pickadate.js/issues/265

First of all, thanks for this great plugin.
The two bugs above are caused by a label tag wrapping the input field. They have been flagged as invalid, but as I must disagree, as it is valid and semantic html.
