### PR TITLE
* Fix iOS 8 error when opening/closing time picker over and over

### DIFF
--- a/lib/themes-source/default.less
+++ b/lib/themes-source/default.less
@@ -36,7 +36,8 @@
     position: fixed;
 
     // Fade out the background, then immediately shift the holder out of view.
-    transition: background @speed-animate-in ease-out, transform 0s @speed-animate-in;
+    transition: background @speed-animate-in ease-out;
+    transform: 0s @speed-animate-in;
 
     // Avoid flickering of the page on webkit browsers
     -webkit-backface-visibility: hidden;


### PR DESCRIPTION
This PR fixes an issue with iOS 8 when opening and closing the time picker over and over. On subsequent clicks, the time picker would intermittently open without actually appearing. Clicking again would select a time as though it was there, then close it.

iOS 8 seemed to be hung up on [this line](https://github.com/amsul/pickadate.js/blob/master/lib/themes-source/default.less#L39), which combines `transition` and `transform` rules. Splitting them into two fixed things.

You can view the problem [here](http://notthisway.com/temp/pickadate-ios8/master.html) and the fixed version [here](http://notthisway.com/temp/pickadate-ios8/tinker.html). (Note that there is also some extra scroll-jumping on that page to work around #609).

