### PR TITLE
Bind events to `P.$holder` again when `render()`

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -171,7 +171,8 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                 // Insert a new component holder in the root or box.
                 if ( entireComponent ) {
-                    P.$holder = createWrappedComponent()
+                    P.$holder = $( createWrappedComponent() )
+                    prepareElementHolder()
                     P.$root.html( P.$holder )
                 }
                 else P.$root.find( '.' + CLASSES.box ).html( P.component.nodes( STATE.open ) )


### PR DESCRIPTION
The event bindings seem to be lost after `render` is invoked with the argument `entireComponent = true`. This adds it back again.