### PR TITLE
Fix close event for IE

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -753,7 +753,9 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 }
 
                 else if ( targetData.close ) {
-                    P.close( true )
+                    setTimeout( function() {
+                      P.close( true )
+                    }, 0 )
                 }
 
             }) //P.$holder


### PR DESCRIPTION
The event cycle is not completely finished before the close method is called which causes IE to not close the datepicker.