### PR TITLE
prevent pickadate from popping up again after refocusing the browser win...

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -386,6 +386,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 // Unbind the document events.
                 $document.off( '.' + STATE.id )
 
+                P.$holder.blur();
                 // Trigger the queued “close” events.
                 return P.trigger( 'close' )
             }, //close


### PR DESCRIPTION
...dow (e.g. after tab switch) when it was already closed