### PR TITLE
Fixed estonian translation 'clear'

### DIFF
--- a/lib/translations/et_EE.js
+++ b/lib/translations/et_EE.js
@@ -6,12 +6,12 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     weekdaysFull: [ 'pühapäev', 'esmaspäev', 'teisipäev', 'kolmapäev', 'neljapäev', 'reede', 'laupäev' ],
     weekdaysShort: [ 'püh', 'esm', 'tei', 'kol', 'nel', 'ree', 'lau' ],
     today: 'täna',
-    clear: 'kustutama',
+    clear: 'kustuta',
     firstDay: 1,
     format: 'd. mmmm yyyy. a',
     formatSubmit: 'yyyy/mm/dd'
 });
 
 jQuery.extend( jQuery.fn.pickatime.defaults, {
-    clear: 'kustutama'
+    clear: 'kustuta'
 });


### PR DESCRIPTION
The estonian translation for 'clear' was wrong. It was 'kustutama', which is the base form, but in this context it needs to be 'kustuta'. This pull would fix that.