### PR TITLE
Correct Catalan verbs according to the Style Guide

### DIFF
--- a/lib/translations/ca_ES.js
+++ b/lib/translations/ca_ES.js
@@ -6,13 +6,13 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     weekdaysFull: [ 'diumenge', 'dilluns', 'dimarts', 'dimecres', 'dijous', 'divendres', 'dissabte' ],
     weekdaysShort: [ 'diu', 'dil', 'dim', 'dmc', 'dij', 'div', 'dis' ],
     today: 'avui',
-    clear: 'esborrar',
-    close: 'tancar',
+    clear: 'esborra',
+    close: 'tanca',
     firstDay: 1,
     format: 'dddd d !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
 
 jQuery.extend( jQuery.fn.pickatime.defaults, {
-    clear: 'esborrar'
+    clear: 'esborra'
 });


### PR DESCRIPTION
Infinitive for verbs that "talk" to the system are not used in Catalan. Imperative is used instead.

[MS Style Guides](http://download.microsoft.com/download/F/0/6/F06507FB-0BEE-4856-86B3-CB7500C5DC01/cat-esp-StyleGuide.pdf) reflect this:

> Use the 2nd person singular of the imperative (tu) to address the system. Unlike English and Spanish, the infinitive form should never be used in Catalan.