### PR TITLE
Fixed setting the STATE.open flag when opening without giving focus

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -246,18 +246,18 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                 }, 0 )
 
+                // Set it as open.
+                STATE.open = true
+
+                // Prevent the page from scrolling.
+                if ( IS_DEFAULT_THEME ) {
+                    $html.
+                        css( 'overflow', 'hidden' ).
+                        css( 'padding-right', '+=' + getScrollbarWidth() )
+                }
+
                 // If we have to give focus, bind the element and doc events.
                 if ( dontGiveFocus !== false ) {
-
-                    // Set it as open.
-                    STATE.open = true
-
-                    // Prevent the page from scrolling.
-                    if ( IS_DEFAULT_THEME ) {
-                        $html.
-                            css( 'overflow', 'hidden' ).
-                            css( 'padding-right', '+=' + getScrollbarWidth() )
-                    }
 
                     // Pass focus to the root element’s jQuery object.
                     focusPickerOnceOpened()


### PR DESCRIPTION
Currently, when calling `open()` passing `false` for `dontGiveFocus` (which incidentally should actually be called `giveFocus`), the STATE.open flag is not set even though the picker is open. This fix moves the STATE.open (and main window scroll prevention) out of the conditional.