### PR TITLE
Added 'updateInput' setting, which can disable updating the input value

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1299,6 +1299,9 @@ DatePicker.defaults = (function( prefix ) {
         closeOnSelect: true,
         closeOnClear: true,
 
+        // Update input value on select/clear
+        updateInput: true,
+
         // The format to show on the `input` element
         format: 'd mmmm, yyyy',
 

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -432,7 +432,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                         }
 
                         // Then, check to update the element value and broadcast a change.
-                        if ( thingItem == 'select' || thingItem == 'clear' ) {
+                        if ( ( thingItem == 'select' || thingItem == 'clear' ) && SETTINGS.updateInput ) {
                             $ELEMENT.
                                 val( thingItem == 'clear' ? '' : P.get( thingItem, SETTINGS.format ) ).
                                 trigger( 'change' )

--- a/lib/picker.time.js
+++ b/lib/picker.time.js
@@ -977,6 +977,9 @@ TimePicker.defaults = (function( prefix ) {
         closeOnSelect: true,
         closeOnClear: true,
 
+        // Update input value on select/clear
+        updateInput: true,
+
         // Classes
         klass: {
 


### PR DESCRIPTION
Added a new setting called `updateInput` that, when false, disables updating the input element's value. Defaults to normal bahaviour (`true`). This allows the user to respond to onSet events and set the input value themselves.
