### PR TITLE
Added inline option

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -105,6 +105,11 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 P.$root = $( '<div class="' + CLASSES.picker + '" id="' + ELEMENT.id + '_root" />' )
                 prepareElementRoot()
 
+                // If we're inline, add the inline class
+                if ( SETTINGS.inline ) {
+                    P.$root.addClass(CLASSES.inline)
+                }
+
 
                 // Create the picker holder and then prepare it.
                 P.$holder = $( createWrappedComponent() ).appendTo( P.$root )
@@ -145,6 +150,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     stop: SETTINGS.onStop,
                     open: SETTINGS.onOpen,
                     close: SETTINGS.onClose,
+                    inlineClose: SETTINGS.onInlineClose,
                     set: SETTINGS.onSet
                 })
 
@@ -154,8 +160,10 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
 
                 // If the element has autofocus, open the picker.
-                if ( ELEMENT.autofocus ) {
-                    P.open()
+                if ( ELEMENT.autofocus || SETTINGS.inline ) {
+                    setTimeout( function() {
+                        P.open()
+                    }, 0)
                 }
 
 
@@ -274,7 +282,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                         // * In Firefox stopPropagation() doesn’t prevent right-click events from bubbling,
                         //   which causes the picker to unexpectedly close when right-clicking it. So make
                         //   sure the event wasn’t a right-click.
-                        if ( target != ELEMENT && target != document && event.which != 3 ) {
+                        if ( target != ELEMENT && target != document && event.which != 3 && !SETTINGS.inline ) {
 
                             // If the target was the holder that covers the screen,
                             // keep the element focused to maintain tabindex.
@@ -339,6 +347,8 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
              * Close the picker
              */
             close: function( giveFocus ) {
+
+              if ( SETTINGS.inline ) return P.trigger( 'inlineClose' )
 
                 // If we need to give focus, do it before changing states.
                 if ( giveFocus ) {
@@ -884,6 +894,7 @@ PickerConstructor.klasses = function( prefix ) {
         picker: prefix,
         opened: prefix + '--opened',
         focused: prefix + '--focused',
+        inline: prefix + '--inline',
 
         input: prefix + '__input',
         active: prefix + '__input--active',

--- a/lib/themes-source/default.less
+++ b/lib/themes-source/default.less
@@ -190,3 +190,41 @@
 }
 
 
+/**
+ * Inline picker...
+ */
+.picker--inline {
+	&.picker {
+		position: static;
+	}
+
+    .picker__holder,
+    .picker__frame {
+        position: static;
+        outline: 0;
+        opacity: 1;
+        background-color: transparent;
+        margin: 0;
+        -webkit-transform: none;
+        -moz-transform: none;
+        -ms-transform: none;
+        -o-transform: none;
+        transform: none;
+        -webkit-transition: none;
+        -moz-transition: none;
+        -ms-transition: none;
+        -o-transition: none;
+        transition: none;
+    }
+
+    .picker__wrap,
+    .picker__box {
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+    }
+
+    .picker__header {
+        margin: 0;
+    }
+}

--- a/lib/themes/default.css
+++ b/lib/themes/default.css
@@ -166,3 +166,31 @@
     bottom: 0;
   }
 }
+/**
+ * Inline picker...
+ */
+.picker--inline.picker {
+  position: static;
+}
+.picker--inline .picker__holder,
+.picker--inline .picker__frame {
+  position: static;
+  outline: 0;
+  opacity: 1;
+  background-color: transparent;
+  margin: 0;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+  -webkit-transition: none;
+  transition: none;
+}
+.picker--inline .picker__wrap,
+.picker--inline .picker__box {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+.picker--inline .picker__header {
+  margin: 0;
+}


### PR DESCRIPTION
New setting `inline`, which adds a `picker--inline` class to the root div. This styles the picker so that it is statically positioned instead of fixed/absolute, as well as cosmetic changes. The setting also disables the close() function, instead triggering an `onInlineClose` event for which a callback can be passed upon picker creation.