### PR TITLE
webpack compatibility

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -7,7 +7,7 @@
 
     // AMD.
     if ( typeof define == 'function' && define.amd )
-        define( ['picker', 'jquery'], factory )
+        define( ['./picker', 'jquery'], factory )
 
     // Node.js/browserify.
     else if ( typeof exports == 'object' )

--- a/lib/picker.time.js
+++ b/lib/picker.time.js
@@ -7,7 +7,7 @@
 
     // AMD.
     if ( typeof define == 'function' && define.amd )
-        define( ['picker', 'jquery'], factory )
+        define( ['./picker', 'jquery'], factory )
 
     // Node.js/browserify.
     else if ( typeof exports == 'object' )


### PR DESCRIPTION
load with `require('pickadate/lib/picker.date')` and/or
`require('pickadate/lib/picker.time')` with jQuery in a global
namespace.

Works with https://github.com/amsul/pickadate.js/pull/772, but #772 is
not necessary.