### PR TITLE
Only month is zero-based

### DIFF
--- a/date.html
+++ b/date.html
@@ -19,7 +19,7 @@ redirect_from: /date.htm
     {% include demo.html class="js__datepicker" %}
 
     <div class="section__block section__block--notification">
-      <p><b>NOTE:</b> months in a JavaScript <code><span class="function">Date</span></code> object are zero-indexed. Meaning, <code><span class="keyword">new</span>&nbsp;<span class="function">Date</span>(<span class="numeric">2015</span>,&nbsp;<span class="numeric">3</span>,&nbsp;<span class="numeric">20</span>)</code> is <u>20&nbsp;April,&nbsp;2016</u>.</p>
+      <p><b>NOTE:</b> months in a JavaScript <code><span class="function">Date</span></code> object are zero-indexed. Meaning, <code><span class="keyword">new</span>&nbsp;<span class="function">Date</span>(<span class="numeric">2015</span>,&nbsp;<span class="numeric">3</span>,&nbsp;<span class="numeric">20</span>)</code> is <u>20&nbsp;April,&nbsp;2015</u>.</p>
       <p>To stay consistent with this, whenever an integer is used in reference to a month, pickadate treats it as zero-indexed. Dates as strings are still parsed as expected.</p>
     </div>
 


### PR DESCRIPTION
Documentation example results in April 20, 2016, however only the month is zero based and it should read April 20, 2015.

``` js
> new Date(2015, 3, 20)
< Mon Apr 20 2015 00:00:00 GMT+0200 (Central Europe Daylight Time)
```
