### PR TITLE
translation of short month

### DIFF
--- a/lib/translations/nl_NL.js
+++ b/lib/translations/nl_NL.js
@@ -2,7 +2,7 @@
 
 jQuery.extend( jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december' ],
-    monthsShort: [ 'jan', 'feb', 'maa', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
+    monthsShort: [ 'jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag' ],
     weekdaysShort: [ 'zo', 'ma', 'di', 'wo', 'do', 'vr', 'za' ],
     today: 'vandaag',


### PR DESCRIPTION
the short version of the dutch version of March is incorrect, it has been fixed in this pull request
