### PR TITLE
Defining and changing locale at runtime

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,7 @@ module.exports = function( grunt ) {
     grunt.loadNpmTasks( 'grunt-contrib-less' )
     grunt.loadNpmTasks( 'grunt-contrib-cssmin' )
     grunt.loadNpmTasks( 'grunt-contrib-uglify' )
+    grunt.loadNpmTasks( 'grunt-contrib-concat' )
     grunt.loadNpmTasks( 'grunt-autoprefixer' )
 
 
@@ -129,6 +130,12 @@ module.exports = function( grunt ) {
             lib: [ '<%= dirs.tests %>/units/all.htm' ]
         },
 
+        concat: {
+            dist: {
+                src: [ '<%= dirs.translations.src %>/*.js' ],
+                dest: '<%= dirs.translations.src %>/all-translations.js'
+            }
+        },
 
         // Watch the project files.
         watch: {
@@ -149,7 +156,7 @@ module.exports = function( grunt ) {
     grunt.registerTask( 'develop', [ 'develop-once', 'watch:develop' ] )
     grunt.registerTask( 'develop-once', [ 'less:themes', 'autoprefixer:themes' ] )
 
-    grunt.registerTask( 'package', [ 'develop-once', 'uglify', 'cssmin' ] )
+    grunt.registerTask( 'package', [ 'develop-once', 'concat', 'uglify', 'cssmin' ] )
 
     grunt.registerTask( 'test', [ 'jshint', 'qunit' ] )
 

--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1283,39 +1283,43 @@ Picker.definedDateOverridesFor = function( locale ) {
     return Picker._definedOverridesFor( 'date', locale )
 }
 
+Picker.defineDateLocale('en_US', {
+    // The title label to use for the month nav buttons
+    labelMonthNext: 'Next month',
+    labelMonthPrev: 'Previous month',
+
+    // The title label to use for the dropdown selectors
+    labelMonthSelect: 'Select a month',
+    labelYearSelect: 'Select a year',
+
+    // Months and weekdays
+    monthsFull: [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ],
+    monthsShort: [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ],
+    weekdaysFull: [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday' ],
+    weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
+
+    // Today and clear
+    today: 'Today',
+    clear: 'Clear',
+    close: 'Close',
+
+    // The format to show on the `input` element
+    format: 'd mmmm, yyyy'
+}, true);
 
 /**
  * The date picker defaults.
  */
 DatePicker.defaults = (function( prefix ) {
 
-    return {
-
-        // The title label to use for the month nav buttons
-        labelMonthNext: 'Next month',
-        labelMonthPrev: 'Previous month',
-
-        // The title label to use for the dropdown selectors
-        labelMonthSelect: 'Select a month',
-        labelYearSelect: 'Select a year',
-
-        // Months and weekdays
-        monthsFull: [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ],
-        monthsShort: [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ],
-        weekdaysFull: [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday' ],
-        weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
-
-        // Today and clear
-        today: 'Today',
-        clear: 'Clear',
-        close: 'Close',
+    return $.extend({}, {
 
         // Picker close behavior
         closeOnSelect: true,
         closeOnClear: true,
 
-        // The format to show on the `input` element
-        format: 'd mmmm, yyyy',
+        firstDay: undefined,
+        formatSubmit: undefined,
 
         // Classes
         klass: {
@@ -1350,7 +1354,7 @@ DatePicker.defaults = (function( prefix ) {
             buttonToday: prefix + 'button--today',
             buttonClose: prefix + 'button--close'
         }
-    }
+    }, Picker.definedDateOverridesFor('en_US'))
 })( Picker.klasses().picker + '__' )
 
 

--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1279,6 +1279,9 @@ Picker.resetDateLocale = function( ) {
     Picker._resetLocale( 'date', $.fn.pickadate.defaults )
 }
 
+Picker.definedDateOverridesFor = function( locale ) {
+    return Picker._definedOverridesFor( 'date', locale )
+}
 
 
 /**

--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1275,6 +1275,10 @@ Picker.useDateLocale = function( locale ) {
     Picker._useLocale( 'date', locale, $.fn.pickadate.defaults )
 }
 
+Picker.resetDateLocale = function( ) {
+    Picker._resetLocale( 'date', $.fn.pickadate.defaults )
+}
+
 
 
 /**

--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1267,6 +1267,14 @@ DatePicker.prototype.nodes = function( isOpen ) {
 } //DatePicker.prototype.nodes
 
 
+Picker.defineDateLocale = function( locale, overrides, dontUseLocaleWhenDefined ) {
+    Picker._defineLocale( 'date', locale, overrides, Picker.useDateLocale, dontUseLocaleWhenDefined )
+}
+
+Picker.useDateLocale = function( locale ) {
+    Picker._useLocale( 'date', locale, $.fn.pickadate.defaults )
+}
+
 
 
 /**
@@ -1337,9 +1345,6 @@ DatePicker.defaults = (function( prefix ) {
         }
     }
 })( Picker.klasses().picker + '__' )
-
-
-
 
 
 /**

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -1121,6 +1121,9 @@ PickerConstructor._resetLocale = function( localeType, jqueryLocaleTypeDefaults 
     }
 }
 
+PickerConstructor._definedOverridesFor = function( localeType, locale ) {
+    return PickerConstructor._localeOverrides[ localeType ][ locale ];
+}
 
 /**
  * Extend the picker with a component and defaults.

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -1075,6 +1075,43 @@ PickerConstructor._ = {
     ariaAttr: ariaAttr
 } //PickerConstructor._
 
+PickerConstructor._localeOverrides = { }
+PickerConstructor._initialOverrides = { }
+PickerConstructor._defineLocale = function( localeType, locale, overrides, useLocaleCallback, dontUseLocaleWhenDefined ) {
+    dontUseLocaleWhenDefined = dontUseLocaleWhenDefined || PickerConstructor.dontUseLocaleWhenDefined;
+
+    PickerConstructor._localeOverrides[localeType] = PickerConstructor._localeOverrides[localeType] || {};
+
+    if(PickerConstructor._localeOverrides[localeType][locale]) {
+        throw new Error("Cannot define locale ["+locale+"] twice for type ["+localeType+"]");
+    }
+
+    PickerConstructor._localeOverrides[localeType][locale] = overrides;
+
+    // For backward compat only : we were applying the overrides as soon as we were defining it
+    if( !dontUseLocaleWhenDefined ) {
+        useLocaleCallback(locale);
+    }
+}
+
+PickerConstructor._useLocale = function( localeType, locale, jqueryLocaleTypeDefaults ) {
+    if ( !PickerConstructor._localeOverrides[localeType] || !PickerConstructor._localeOverrides[localeType][locale] ) {
+        throw new Error( "Locale [" + locale + "] for type [" + localeType + "] has not been defined yet !" )
+    }
+
+    var localeOverrides = PickerConstructor._localeOverrides[localeType][ locale ];
+
+    // The first time useLocale() is called, remembering default jquery overrides
+    // and using it to reset default overrides on subsequent calls
+    if( !PickerConstructor._initialOverrides[localeType] ) {
+        PickerConstructor._initialOverrides[localeType] = $.extend({}, jqueryLocaleTypeDefaults);
+    } else {
+        // Resetting overrides to initial values before applying new locale overrides
+        $.extend( jqueryLocaleTypeDefaults, PickerConstructor._initialOverrides[localeType] )
+    }
+
+    $.extend( jqueryLocaleTypeDefaults, localeOverrides )
+}
 
 
 /**

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -1113,6 +1113,14 @@ PickerConstructor._useLocale = function( localeType, locale, jqueryLocaleTypeDef
     $.extend( jqueryLocaleTypeDefaults, localeOverrides )
 }
 
+PickerConstructor._resetLocale = function( localeType, jqueryLocaleTypeDefaults ) {
+    if( PickerConstructor._initialOverrides[ localeType ] ) {
+        $.extend( jqueryLocaleTypeDefaults, PickerConstructor._initialOverrides[localeType] )
+
+        delete PickerConstructor._initialOverrides[localeType]
+    }
+}
+
 
 /**
  * Extend the picker with a component and defaults.

--- a/lib/picker.time.js
+++ b/lib/picker.time.js
@@ -962,6 +962,9 @@ Picker.useTimeLocale = function( locale ) {
     Picker._useLocale( 'time', locale, $.fn.pickatime.defaults )
 }
 
+Picker.resetTimeLocale = function( ) {
+    Picker._resetLocale( 'time', $.fn.pickatime.defaults )
+}
 
 
 /**

--- a/lib/picker.time.js
+++ b/lib/picker.time.js
@@ -971,18 +971,21 @@ Picker.definedTimeOverridesFor = function( locale ) {
 }
 
 
+Picker.defineTimeLocale('en_US', {
+    // Clear
+    clear: 'Clear',
+
+    // The format to show on the `input` element
+    format: 'h:i A'
+
+}, true);
+
 /**
  * Extend the picker to add the component with the defaults.
  */
 TimePicker.defaults = (function( prefix ) {
 
-    return {
-
-        // Clear
-        clear: 'Clear',
-
-        // The format to show on the `input` element
-        format: 'h:i A',
+    return $.extend({}, {
 
         // The interval between each time
         interval: 30,
@@ -1008,7 +1011,7 @@ TimePicker.defaults = (function( prefix ) {
 
             buttonClear: prefix + '__button--clear'
         }
-    }
+    }, Picker.definedTimeOverridesFor('en_US'))
 })( Picker.klasses().picker )
 
 

--- a/lib/picker.time.js
+++ b/lib/picker.time.js
@@ -954,6 +954,13 @@ TimePicker.prototype.nodes = function( isOpen ) {
 
 
 
+Picker.defineTimeLocale = function( locale, overrides, dontUseLocaleWhenDefined ) {
+    Picker._defineLocale( 'time', locale, overrides, Picker.useTimeLocale, dontUseLocaleWhenDefined )
+}
+
+Picker.useTimeLocale = function( locale ) {
+    Picker._useLocale( 'time', locale, $.fn.pickatime.defaults )
+}
 
 
 
@@ -996,9 +1003,6 @@ TimePicker.defaults = (function( prefix ) {
         }
     }
 })( Picker.klasses().picker )
-
-
-
 
 
 /**

--- a/lib/picker.time.js
+++ b/lib/picker.time.js
@@ -966,6 +966,10 @@ Picker.resetTimeLocale = function( ) {
     Picker._resetLocale( 'time', $.fn.pickatime.defaults )
 }
 
+Picker.definedTimeOverridesFor = function( locale ) {
+    return Picker._definedOverridesFor( 'time', locale )
+}
+
 
 /**
  * Extend the picker to add the component with the defaults.

--- a/lib/translations/ar.js
+++ b/lib/translations/ar.js
@@ -1,6 +1,11 @@
 // Arabic
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+    'use strict';
+Picker.defineDateLocale('ar', {
     monthsFull: [ 'يناير', 'فبراير', 'مارس', 'ابريل', 'مايو', 'يونيو', 'يوليو', 'اغسطس', 'سبتمبر', 'اكتوبر', 'نوفمبر', 'ديسمبر' ],
     monthsShort: [ 'يناير', 'فبراير', 'مارس', 'ابريل', 'مايو', 'يونيو', 'يوليو', 'اغسطس', 'سبتمبر', 'اكتوبر', 'نوفمبر', 'ديسمبر' ],
     weekdaysFull: [ 'الاحد', 'الاثنين', 'الثلاثاء', 'الاربعاء', 'الخميس', 'الجمعة', 'السبت' ],
@@ -11,6 +16,8 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('ar', {
     clear: 'مسح'
 });
+
+}));

--- a/lib/translations/bg_BG.js
+++ b/lib/translations/bg_BG.js
@@ -1,6 +1,10 @@
 // Bulgarian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('bg_BG', {
     monthsFull: [ 'януари','февруари','март','април','май','юни','юли','август','септември','октомври','ноември','декември' ],
     monthsShort: [ 'янр','фев','мар','апр','май','юни','юли','авг','сеп','окт','ное','дек' ],
     weekdaysFull: [ 'неделя', 'понеделник', 'вторник', 'сряда', 'четвъртък', 'петък', 'събота' ],
@@ -12,6 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('bg_BG', {
     clear: 'изтривам'
 });
+}));

--- a/lib/translations/bs_BA.js
+++ b/lib/translations/bs_BA.js
@@ -1,6 +1,11 @@
 // Bosnian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('bs_BA', {
     monthsFull: [ 'januar', 'februar', 'mart', 'april', 'maj', 'juni', 'juli', 'august', 'septembar', 'oktobar', 'novembar', 'decembar' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'nedjelja', 'ponedjeljak', 'utorak', 'srijeda', 'cetvrtak', 'petak', 'subota' ],
@@ -12,6 +17,8 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('bs_BA', {
     clear: 'izbrisati'
 });
+
+}));

--- a/lib/translations/ca_ES.js
+++ b/lib/translations/ca_ES.js
@@ -1,6 +1,11 @@
 // Catalan
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('ca_ES', {
     monthsFull: [ 'Gener', 'Febrer', 'Març', 'Abril', 'Maig', 'juny', 'Juliol', 'Agost', 'Setembre', 'Octubre', 'Novembre', 'Desembre' ],
     monthsShort: [ 'Gen', 'Feb', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Oct', 'Nov', 'Des' ],
     weekdaysFull: [ 'diumenge', 'dilluns', 'dimarts', 'dimecres', 'dijous', 'divendres', 'dissabte' ],
@@ -13,6 +18,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('ca_ES', {
     clear: 'esborrar'
 });
+}));

--- a/lib/translations/cs_CZ.js
+++ b/lib/translations/cs_CZ.js
@@ -1,6 +1,11 @@
 // Czech
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('cs_CZ', {
     monthsFull: [ 'leden', 'únor', 'březen', 'duben', 'květen', 'červen', 'červenec', 'srpen', 'září', 'říjen', 'listopad', 'prosinec' ],
     monthsShort: [ 'led', 'úno', 'bře', 'dub', 'kvě', 'čer', 'čvc', 'srp', 'zář', 'říj', 'lis', 'pro' ],
     weekdaysFull: [ 'neděle', 'pondělí', 'úterý', 'středa', 'čtvrtek', 'pátek', 'sobota' ],
@@ -12,6 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('cs_CZ', {
     clear: 'vymazat'
 });
+}));

--- a/lib/translations/da_DK.js
+++ b/lib/translations/da_DK.js
@@ -1,6 +1,11 @@
 // Danish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('da_DK', {
     monthsFull: [ 'januar', 'februar', 'marts', 'april', 'maj', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag' ],
@@ -13,6 +18,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('da_DK', {
     clear: 'slet'
 });
+}));

--- a/lib/translations/de_DE.js
+++ b/lib/translations/de_DE.js
@@ -1,6 +1,11 @@
 // German
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('de_DE', {
     monthsFull: [ 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember' ],
     monthsShort: [ 'Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez' ],
     weekdaysFull: [ 'Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag' ],
@@ -13,6 +18,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('de_DE', {
     clear: 'Löschen'
 });
+}));

--- a/lib/translations/el_GR.js
+++ b/lib/translations/el_GR.js
@@ -1,6 +1,10 @@
 // Greek
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('el_GR', {
     monthsFull: [ 'Ιανουάριος', 'Φεβρουάριος', 'Μάρτιος', 'Απρίλιος', 'Μάιος', 'Ιούνιος', 'Ιούλιος', 'Αύγουστος', 'Σεπτέμβριος', 'Οκτώβριος', 'Νοέμβριος', 'Δεκέμβριος' ],
     monthsShort: [ 'Ιαν', 'Φεβ', 'Μαρ', 'Απρ', 'Μαι', 'Ιουν', 'Ιουλ', 'Αυγ', 'Σεπ', 'Οκτ', 'Νοε', 'Δεκ' ],
     weekdaysFull: [ 'Κυριακή', 'Δευτέρα', 'Τρίτη', 'Τετάρτη', 'Πέμπτη', 'Παρασκευή', 'Σάββατο' ],
@@ -12,6 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('el_GR', {
     clear: 'Διαγραφή'
 });
+}));

--- a/lib/translations/es_ES.js
+++ b/lib/translations/es_ES.js
@@ -1,6 +1,11 @@
 // Spanish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('es_ES', {
     monthsFull: [ 'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre' ],
     monthsShort: [ 'ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic' ],
     weekdaysFull: [ 'domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado' ],
@@ -13,6 +18,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('es_ES', {
     clear: 'borrar'
 });
+}));

--- a/lib/translations/et_EE.js
+++ b/lib/translations/et_EE.js
@@ -1,6 +1,11 @@
 // Estonian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('et_EE', {
     monthsFull: [ 'jaanuar', 'veebruar', 'märts', 'aprill', 'mai', 'juuni', 'juuli', 'august', 'september', 'oktoober', 'november', 'detsember' ],
     monthsShort: [ 'jaan', 'veebr', 'märts', 'apr', 'mai', 'juuni', 'juuli', 'aug', 'sept', 'okt', 'nov', 'dets' ],
     weekdaysFull: [ 'pühapäev', 'esmaspäev', 'teisipäev', 'kolmapäev', 'neljapäev', 'reede', 'laupäev' ],
@@ -12,6 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('et_EE', {
     clear: 'kustutama'
 });
+}));

--- a/lib/translations/eu_ES.js
+++ b/lib/translations/eu_ES.js
@@ -1,6 +1,10 @@
 // Basque
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('eu_ES', {
     monthsFull: [ 'urtarrila', 'otsaila', 'martxoa', 'apirila', 'maiatza', 'ekaina', 'uztaila', 'abuztua', 'iraila', 'urria', 'azaroa', 'abendua' ],
     monthsShort: [ 'urt', 'ots', 'mar', 'api', 'mai', 'eka', 'uzt', 'abu', 'ira', 'urr', 'aza', 'abe' ],
     weekdaysFull: [ 'igandea', 'astelehena', 'asteartea', 'asteazkena', 'osteguna', 'ostirala', 'larunbata' ],
@@ -12,6 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+    Picker.defineTimeLocale('eu_ES', {
     clear: 'garbitu'
 });
+}));

--- a/lib/translations/fa_IR.js
+++ b/lib/translations/fa_IR.js
@@ -1,6 +1,11 @@
 // Farsi
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('fa_ir', {
     monthsFull: [ 'ژانویه', 'فوریه', 'مارس', 'آوریل', 'مه', 'ژوئن', 'ژوئیه', 'اوت', 'سپتامبر', 'اکتبر', 'نوامبر', 'دسامبر'],
     monthsShort: [ 'ژانویه', 'فوریه', 'مارس', 'آوریل', 'مه', 'ژوئن', 'ژوئیه', 'اوت', 'سپتامبر', 'اکتبر', 'نوامبر', 'دسامبر' ],
     weekdaysFull: [ 'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه' ],
@@ -14,6 +19,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
 	labelMonthPrev: 'ماه قبلی'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+    Picker.defineTimeLocale('fa_ir', {
     clear: 'پاک کردن'
 });
+}));

--- a/lib/translations/fa_ir.js
+++ b/lib/translations/fa_ir.js
@@ -1,6 +1,11 @@
 // Farsi
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('fa_ir', {
     monthsFull: [ 'ژانویه', 'فوریه', 'مارس', 'آوریل', 'مه', 'ژوئن', 'ژوئیه', 'اوت', 'سپتامبر', 'اکتبر', 'نوامبر', 'دسامبر'],
     monthsShort: [ 'ژانویه', 'فوریه', 'مارس', 'آوریل', 'مه', 'ژوئن', 'ژوئیه', 'اوت', 'سپتامبر', 'اکتبر', 'نوامبر', 'دسامبر' ],
     weekdaysFull: [ 'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه' ],
@@ -14,6 +19,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
 	labelMonthPrev: 'ماه قبلی'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+    Picker.defineTimeLocale('fa_ir', {
     clear: 'پاک کردن'
 });
+}));

--- a/lib/translations/fi_FI.js
+++ b/lib/translations/fi_FI.js
@@ -1,6 +1,11 @@
 // Finnish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('fi_FI', {
     monthsFull: [ 'tammikuu', 'helmikuu', 'maaliskuu', 'huhtikuu', 'toukokuu', 'kesäkuu', 'heinäkuu', 'elokuu', 'syyskuu', 'lokakuu', 'marraskuu', 'joulukuu' ],
     monthsShort: [ 'tammi', 'helmi', 'maalis', 'huhti', 'touko', 'kesä', 'heinä', 'elo', 'syys', 'loka', 'marras', 'joulu' ],
     weekdaysFull: [ 'sunnuntai', 'maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai' ],
@@ -12,6 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('fi_FI', {
     clear: 'tyhjennä'
 });
+}));

--- a/lib/translations/fr_FR.js
+++ b/lib/translations/fr_FR.js
@@ -1,6 +1,10 @@
 // French
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('fr_FR', {
     monthsFull: [ 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre' ],
     monthsShort: [ 'Jan', 'Fev', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Dec' ],
     weekdaysFull: [ 'Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi' ],
@@ -17,6 +21,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelYearSelect:"Sélectionner une année"
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+    Picker.defineTimeLocale('fr_FR', {
     clear: 'Effacer'
 });
+}));

--- a/lib/translations/gl_ES.js
+++ b/lib/translations/gl_ES.js
@@ -1,6 +1,10 @@
 // Galician
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('gl_ES', {
     monthsFull: [ 'Xaneiro', 'Febreiro', 'Marzo', 'Abril', 'Maio', 'Xuño', 'Xullo', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Decembro' ],
     monthsShort: [ 'xan', 'feb', 'mar', 'abr', 'mai', 'xun', 'xul', 'ago', 'sep', 'out', 'nov', 'dec' ],
     weekdaysFull: [ 'domingo', 'luns', 'martes', 'mércores', 'xoves', 'venres', 'sábado' ],
@@ -12,6 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+    Picker.defineTimeLocale('gl_ES', {
     clear: 'borrar'
 });
+}));

--- a/lib/translations/he_IL.js
+++ b/lib/translations/he_IL.js
@@ -1,6 +1,10 @@
 // Hebrew
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('he_IL', {
     monthsFull: [ 'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר' ],
     monthsShort: [ 'ינו', 'פבר', 'מרץ', 'אפר', 'מאי', 'יונ', 'יול', 'אוג', 'ספט', 'אוק', 'נוב', 'דצמ' ],
     weekdaysFull: [ 'יום ראשון', 'יום שני', 'יום שלישי', 'יום רביעי', 'יום חמישי', 'יום ששי', 'יום שבת' ],
@@ -11,6 +15,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('he_IL', {
     clear: 'למחוק'
 });
+}));

--- a/lib/translations/hi_IN.js
+++ b/lib/translations/hi_IN.js
@@ -1,4 +1,9 @@
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('hi_IN', {
     monthsFull: [ 'जनवरी', 'फरवरी', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अगस्त', 'सितम्बर', 'अक्टूबर', 'नवम्बर', 'दिसम्बर' ],
     monthsShort: [ 'जन', 'फर', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जु', 'अग', 'सित', 'अक्टू', 'नव', 'दिस' ],
     weekdaysFull: [ 'रविवार', 'सोमवार', 'मंगलवार', 'बुधवार', 'गुरुवार', 'शुक्रवार', 'शनिवार' ],
@@ -15,6 +20,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelYearSelect: 'किसि एक वर्ष का चयन करें'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('hi_IN', {
     clear: 'चुनी हुई तारीख को मिटाएँ'
 });
+}));

--- a/lib/translations/hr_HR.js
+++ b/lib/translations/hr_HR.js
@@ -1,6 +1,11 @@
 // Croatian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+
+Picker.defineDateLocale('hr_HR', {
     monthsFull: [ 'sijećanj', 'veljača', 'ožujak', 'travanj', 'svibanj', 'lipanj', 'srpanj', 'kolovoz', 'rujan', 'listopad', 'studeni', 'prosinac' ],
     monthsShort: [ 'sij', 'velj', 'ožu', 'tra', 'svi', 'lip', 'srp', 'kol', 'ruj', 'lis', 'stu', 'pro' ],
     weekdaysFull: [ 'nedjelja', 'ponedjeljak', 'utorak', 'srijeda', 'četvrtak', 'petak', 'subota' ],
@@ -12,6 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('hr_HR', {
     clear: 'izbrisati'
 });
+}));

--- a/lib/translations/hu_HU.js
+++ b/lib/translations/hu_HU.js
@@ -1,6 +1,10 @@
 // Hungarian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('hu_HU', {
     monthsFull: [ 'január', 'február', 'március', 'április', 'május', 'június', 'július', 'augusztus', 'szeptember', 'október', 'november', 'december' ],
     monthsShort: [ 'jan', 'febr', 'márc', 'ápr', 'máj', 'jún', 'júl', 'aug', 'szept', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'vasárnap', 'hétfő', 'kedd', 'szerda', 'csütörtök', 'péntek', 'szombat' ],
@@ -12,6 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('hu_HU', {
     clear: 'Törlés'
 });
+}));

--- a/lib/translations/id_ID.js
+++ b/lib/translations/id_ID.js
@@ -1,6 +1,10 @@
 // Indonesian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('id_ID', {
     monthsFull: [ 'Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni', 'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember' ],
     monthsShort: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Mei', 'Jun', 'Jul', 'Agu', 'Sep', 'Okt', 'Nov', 'Des' ],
     weekdaysFull: [ 'Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu' ],
@@ -12,6 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('id_ID', {
     clear: 'menghapus'
 });
+}));

--- a/lib/translations/is_IS.js
+++ b/lib/translations/is_IS.js
@@ -1,6 +1,10 @@
 // Icelandic
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('is_IS', {
     monthsFull: [ 'janúar', 'febrúar', 'mars', 'apríl', 'maí', 'júní', 'júlí', 'ágúst', 'september', 'október', 'nóvember', 'desember' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maí', 'jún', 'júl', 'ágú', 'sep', 'okt', 'nóv', 'des' ],
     weekdaysFull: [ 'sunnudagur', 'mánudagur', 'þriðjudagur', 'miðvikudagur', 'fimmtudagur', 'föstudagur', 'laugardagur' ],
@@ -12,6 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('is_IS', {
     clear: 'Hreinsa'
 });
+}));

--- a/lib/translations/it_IT.js
+++ b/lib/translations/it_IT.js
@@ -1,6 +1,12 @@
 // Italian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+
+Picker.defineDateLocale('it_IT', {
     monthsFull: [ 'gennaio', 'febbraio', 'marzo', 'aprile', 'maggio', 'giugno', 'luglio', 'agosto', 'settembre', 'ottobre', 'novembre', 'dicembre' ],
     monthsShort: [ 'gen', 'feb', 'mar', 'apr', 'mag', 'giu', 'lug', 'ago', 'set', 'ott', 'nov', 'dic' ],
     weekdaysFull: [ 'domenica', 'lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato' ],
@@ -16,9 +22,10 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelMonthSelect: 'Seleziona un mese',
     labelYearSelect: 'Seleziona un anno'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('it_IT', {
     clear: 'Cancella',
     format: 'HH:i',
     formatSubmit: 'HH:i'
 });
+
+}));

--- a/lib/translations/ja_JP.js
+++ b/lib/translations/ja_JP.js
@@ -1,6 +1,11 @@
 // Japanese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('ja_JP', {
     monthsFull: [ '1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月' ],
     monthsShort: [ '1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月' ],
     weekdaysFull: [ '日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日' ],
@@ -11,7 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy mm dd',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('ja_JP', {
     clear: '消去'
 });
+}));

--- a/lib/translations/ko_KR.js
+++ b/lib/translations/ko_KR.js
@@ -1,6 +1,11 @@
 // Korean
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale( 'ko_KR', {
     monthsFull: [ '1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월' ],
     monthsShort: [ '1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월' ],
     weekdaysFull: [ '일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일' ],
@@ -11,7 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy 년 mm 월 dd 일',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('ko_KR', {
     clear: '취소'
 });
+}));

--- a/lib/translations/lt_LT.js
+++ b/lib/translations/lt_LT.js
@@ -1,6 +1,12 @@
 // Lietuviškai
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+
+Picker.defineDateLocale('lt_LT', {
     labelMonthNext: 'Sekantis mėnuo',
     labelMonthPrev: 'Ankstesnis mėnuo',
     labelMonthSelect: 'Pasirinkite mėnesį',
@@ -17,8 +23,9 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy-mm-dd',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('lt_LT', {
     clear: 'Išvalyti',
     format: 'HH:i'
 });
+
+}));

--- a/lib/translations/lv_LV.js
+++ b/lib/translations/lv_LV.js
@@ -1,6 +1,12 @@
 // Latvian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+
+Picker.defineDateLocale('lv_LV', {
     monthsFull: [ 'Janvāris', 'Februāris', 'Marts', 'Aprīlis', 'Maijs', 'Jūnijs', 'Jūlijs', 'Augusts', 'Septembris', 'Oktobris', 'Novembris', 'Decembris' ],
     monthsShort: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jūn', 'Jūl', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec' ],
     weekdaysFull: [ 'Svētdiena', 'Pirmdiena', 'Otrdiena', 'Trešdiena', 'Ceturtdiena', 'Piektdiena', 'Sestdiena' ],
@@ -11,3 +17,5 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy.mm.dd. dddd',
     formatSubmit: 'yyyy/mm/dd'
 });
+
+}));

--- a/lib/translations/nb_NO.js
+++ b/lib/translations/nb_NO.js
@@ -1,6 +1,10 @@
 // Norwegian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('nb_NO', {
     monthsFull: [ 'januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des' ],
     weekdaysFull: [ 'søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag' ],
@@ -12,7 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd. mmm. yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('nb_NO', {
     clear: 'nullstill'
 });
+}));

--- a/lib/translations/ne_NP.js
+++ b/lib/translations/ne_NP.js
@@ -1,6 +1,10 @@
 // Nepali
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+}(this, function (Picker) {
+Picker.defineDateLocale('ne_NP', {
     monthsFull: [ 'जनवरी', 'फेब्रुअरी', 'मार्च', 'अप्रिल', 'मे', 'जुन', 'जुलाई', 'अगस्त', 'सेप्टेम्बर', 'अक्टोबर', 'नोवेम्बर', 'डिसेम्बर' ],
     monthsShort: [ 'जन', 'फेब्रु', 'मार्च', 'अप्रिल', 'मे', 'जुन', 'जुल', 'अग', 'सेप्टे', 'अक्टो', 'नोभे', 'डिसे' ],
     weekdaysFull: [ 'सोमबार', 'मङ्लबार', 'बुधबार', 'बिहीबार', 'शुक्रबार', 'शनिबार', 'आईतबार' ],
@@ -11,7 +15,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd, dd mmmm, yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('ne_NP', {
     clear: 'मेटाउनुहोस्'
 });
+}));

--- a/lib/translations/nl_NL.js
+++ b/lib/translations/nl_NL.js
@@ -1,6 +1,11 @@
 // Dutch
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('nl_NL', {
     monthsFull: [ 'januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'maa', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd d mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('nl_NL', {
     clear: 'verwijderen'
 });
+}));

--- a/lib/translations/pl_PL.js
+++ b/lib/translations/pl_PL.js
@@ -1,6 +1,11 @@
 // Polish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('pl_PL', {
     monthsFull: [ 'styczeń', 'luty', 'marzec', 'kwiecień', 'maj', 'czerwiec', 'lipiec', 'sierpień', 'wrzesień', 'październik', 'listopad', 'grudzień' ],
     monthsShort: [ 'sty', 'lut', 'mar', 'kwi', 'maj', 'cze', 'lip', 'sie', 'wrz', 'paź', 'lis', 'gru' ],
     weekdaysFull: [ 'niedziela', 'poniedziałek', 'wtorek', 'środa', 'czwartek', 'piątek', 'sobota' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('pl_PL', {
     clear: 'usunąć'
 });
+}));

--- a/lib/translations/pt_BR.js
+++ b/lib/translations/pt_BR.js
@@ -1,6 +1,11 @@
 // Brazilian Portuguese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('pt_BR', {
     monthsFull: [ 'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho', 'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro' ],
     monthsShort: [ 'jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez' ],
     weekdaysFull: [ 'domingo', 'segunda-feira', 'terça-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sábado' ],
@@ -11,7 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dddd, d !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('pt_BR', {
     clear: 'limpar'
 });
+}));

--- a/lib/translations/pt_PT.js
+++ b/lib/translations/pt_PT.js
@@ -1,6 +1,11 @@
 // Portuguese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('pt_PT', {
     monthsFull: [ 'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro' ],
     monthsShort: [ 'jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez' ],
     weekdaysFull: [ 'Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado' ],
@@ -11,7 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd !de mmmm !de yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('pt_PT', {
     clear: 'Limpar'
 });
+}));

--- a/lib/translations/ro_RO.js
+++ b/lib/translations/ro_RO.js
@@ -1,6 +1,11 @@
 // Romanian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('ro_RO', {
     monthsFull: [ 'ianuarie', 'februarie', 'martie', 'aprilie', 'mai', 'iunie', 'iulie', 'august', 'septembrie', 'octombrie', 'noiembrie', 'decembrie' ],
     monthsShort: [ 'ian', 'feb', 'mar', 'apr', 'mai', 'iun', 'iul', 'aug', 'sep', 'oct', 'noi', 'dec' ],
     weekdaysFull: [ 'duminică', 'luni', 'marţi', 'miercuri', 'joi', 'vineri', 'sâmbătă' ],
@@ -11,7 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('ro_RO', {
     clear: 'șterge'
 });
+}));

--- a/lib/translations/ru_RU.js
+++ b/lib/translations/ru_RU.js
@@ -1,6 +1,11 @@
 // Russian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('ru_RU', {
     monthsFull: [ 'января', 'февраля', 'марта', 'апреля', 'мая', 'июня', 'июля', 'августа', 'сентября', 'октября', 'ноября', 'декабря' ],
     monthsShort: [ 'янв', 'фев', 'мар', 'апр', 'май', 'июн', 'июл', 'авг', 'сен', 'окт', 'ноя', 'дек' ],
     weekdaysFull: [ 'воскресенье', 'понедельник', 'вторник', 'среда', 'четверг', 'пятница', 'суббота' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy г.',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('ru_RU', {
     clear: 'удалить'
 });
+}));

--- a/lib/translations/sk_SK.js
+++ b/lib/translations/sk_SK.js
@@ -1,6 +1,11 @@
 // Slovak
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('sk_SK', {
     monthsFull: [ 'január', 'február', 'marec', 'apríl', 'máj', 'jún', 'júl', 'august', 'september', 'október', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'máj', 'jún', 'júl', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'nedeľa', 'pondelok', 'utorok', 'streda', 'štvrtok', 'piatok', 'sobota' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('sk_SK', {
     clear: 'vymazať'
 });
+}));

--- a/lib/translations/sl_SI.js
+++ b/lib/translations/sl_SI.js
@@ -1,6 +1,11 @@
 // Slovenian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('sl_SI', {
     monthsFull: [ 'januar', 'februar', 'marec', 'april', 'maj', 'junij', 'julij', 'avgust', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'avg', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'nedelja', 'ponedeljek', 'torek', 'sreda', 'četrtek', 'petek', 'sobota' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd. mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('sl_SI', {
     clear: 'izbriši'
 });
+}));

--- a/lib/translations/sv_SE.js
+++ b/lib/translations/sv_SE.js
@@ -1,6 +1,11 @@
 // Swedish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('sv_SE', {
     monthsFull: [ 'januari', 'februari', 'mars', 'april', 'maj', 'juni', 'juli', 'augusti', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'söndag', 'måndag', 'tisdag', 'onsdag', 'torsdag', 'fredag', 'lördag' ],
@@ -16,7 +21,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelMonthSelect: 'Välj månad',
     labelYearSelect: 'Välj år'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('sv_SE', {
     clear: 'Rensa'
 });
+}));

--- a/lib/translations/th_TH.js
+++ b/lib/translations/th_TH.js
@@ -1,6 +1,11 @@
 // Thai
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('th_TH', {
     monthsFull: [ 'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม' ],
     monthsShort: [ 'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.', 'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.' ],
     weekdaysFull: [ 'อาทติย', 'จันทร', 'องัคาร', 'พุธ', 'พฤหสั บดี', 'ศกุร', 'เสาร' ],
@@ -10,7 +15,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'd mmmm yyyy',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('th_TH', {
     clear: 'ลบ'
 });
+}));

--- a/lib/translations/tr_TR.js
+++ b/lib/translations/tr_TR.js
@@ -1,6 +1,11 @@
 // Turkish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('tr_TR', {
     monthsFull: [ 'Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran', 'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık' ],
     monthsShort: [ 'Oca', 'Şub', 'Mar', 'Nis', 'May', 'Haz', 'Tem', 'Ağu', 'Eyl', 'Eki', 'Kas', 'Ara' ],
     weekdaysFull: [ 'Pazar', 'Pazartesi', 'Salı', 'Çarşamba', 'Perşembe', 'Cuma', 'Cumartesi' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd mmmm yyyy dddd',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('tr_TR', {
     clear: 'sil'
 });
+}));

--- a/lib/translations/uk_UA.js
+++ b/lib/translations/uk_UA.js
@@ -1,6 +1,11 @@
 // Ukrainian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('uk_UA', {
     monthsFull: [ 'січень', 'лютий', 'березень', 'квітень', 'травень', 'червень', 'липень', 'серпень', 'вересень', 'жовтень', 'листопад', 'грудень' ],
     monthsShort: [ 'січ', 'лют', 'бер', 'кві', 'тра', 'чер', 'лип', 'сер', 'вер', 'жов', 'лис', 'гру' ],
     weekdaysFull: [ 'неділя', 'понеділок', 'вівторок', 'середа', 'четвер', 'п‘ятниця', 'субота' ],
@@ -11,7 +16,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'dd mmmm yyyy p.',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('uk_UA', {
     clear: 'викреслити'
 });
+}));

--- a/lib/translations/vi_VN.js
+++ b/lib/translations/vi_VN.js
@@ -1,6 +1,11 @@
 // Vietnamese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('vi_VN', {
     monthsFull: [ 'Tháng Một', 'Tháng Hai', 'Tháng Ba', 'Tháng Tư', 'Tháng Năm', 'Tháng Sáu', 'Tháng Bảy', 'Tháng Tám', 'Tháng Chín', 'Tháng Mười', 'Tháng Mười Một', 'Tháng Mười Hai' ],
     monthsShort: [ 'Một', 'Hai', 'Ba', 'Tư', 'Năm', 'Sáu', 'Bảy', 'Tám', 'Chín', 'Mưới', 'Mười Một', 'Mười Hai' ],
     weekdaysFull: [ 'Chủ Nhật', 'Thứ Hai', 'Thứ Ba', 'Thứ Tư', 'Thứ Năm', 'Thứ Sáu', 'Thứ Bảy' ],
@@ -9,7 +14,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     clear: 'Xoá',
     firstDay: 1
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('vi_VN', {
     clear: 'Xoá'
 });
+}));

--- a/lib/translations/zh_CN.js
+++ b/lib/translations/zh_CN.js
@@ -1,6 +1,11 @@
 // Simplified Chinese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('zh_CN', {
     monthsFull: [ '一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月' ],
     monthsShort: [ '一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二' ],
     weekdaysFull: [ '星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy 年 mm 月 dd 日',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('zh_CN', {
     clear: '清除'
 });
+}));

--- a/lib/translations/zh_TW.js
+++ b/lib/translations/zh_TW.js
@@ -1,6 +1,11 @@
 // Traditional Chinese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+(function (global, factory) {
+   return typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../picker')) :
+   typeof define === 'function' && define.amd ? define(['picker'], factory) : factory(global.Picker)
+
+}(this, function (Picker) {
+Picker.defineDateLocale('zh_TW', {
     monthsFull: [ '一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月' ],
     monthsShort: [ '一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二' ],
     weekdaysFull: [ '星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六' ],
@@ -12,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     format: 'yyyy 年 mm 月 dd 日',
     formatSubmit: 'yyyy/mm/dd'
 });
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+Picker.defineTimeLocale('zh_TW', {
     clear: '清除'
 });
+}));

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "glob": "^5.0.5",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^3.0.0",
+    "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "^0.12.2",
     "grunt-contrib-jshint": "^0.11.2",

--- a/tests/units/all.htm
+++ b/tests/units/all.htm
@@ -13,6 +13,9 @@
     <script src="../../lib/picker.js"></script>
     <script src="../../lib/picker.date.js"></script>
     <script src="../../lib/picker.time.js"></script>
+    <script type="text/javascript">Picker.dontUseLocaleWhenDefined = true;</script>
+    <script src="../../lib/translations/fr_FR.js"></script>
+    <script src="../../lib/translations/es_ES.js"></script>
     <script src="../qunit.js"></script>
     <script src="base.js"></script>
     <script src="date.js"></script>

--- a/tests/units/date.js
+++ b/tests/units/date.js
@@ -1527,3 +1527,35 @@ test( 'the pre-filled `value` selected is no longer "active"', function() {
     deepEqual( [select.year, select.month, select.date], [2014, 7, 14], 'Sets the default select' )
 
 })
+
+module( 'I18N', {
+    teardown: function() {
+        $DOM.empty()
+        Picker.resetDateLocale()
+    }
+})
+
+function ensureTodayButtonLabelIsEqualTo(expectedLabel, $input ) {
+    var $inputPicker = $input.pickadate();
+    var picker = $inputPicker.pickadate( 'picker' )
+    strictEqual( picker.$root.find( '.' + $.fn.pickadate.defaults.klass.buttonToday).text(), expectedLabel )
+    picker.stop();
+}
+
+test( 'we can change current locale and it updates subsequent date picker calls', function() {
+
+    $DOM.append( $INPUT.clone() )
+    var $input = $DOM.find( 'input' )
+
+    ensureTodayButtonLabelIsEqualTo( 'Today', $input )
+
+    // Now, changing the locale
+    Picker.useDateLocale("fr_FR")
+
+    ensureTodayButtonLabelIsEqualTo( 'Aujourd\'hui', $input )
+
+    // Falling back to the default EN locale
+    Picker.useDateLocale("en_US")
+
+    ensureTodayButtonLabelIsEqualTo( 'Today', $input )
+})

--- a/tests/units/time.js
+++ b/tests/units/time.js
@@ -1206,5 +1206,34 @@ test( '`data-value` to select, highlight, and view', function() {
     strictEqual( picker.get( 'view' ).pick, 840, 'Viewsets time' )
 })
 
+module( 'I18N', {
+    teardown: function() {
+        $DOM.empty()
+        Picker.resetTimeLocale()
+    }
+})
 
+function ensureClearButtonLabelIsEqualTo(expectedLabel, $input ) {
+    var $inputPicker = $input.pickatime();
+    var picker = $inputPicker.pickatime( 'picker' )
+    strictEqual( picker.$root.find( '.' + $.fn.pickatime.defaults.klass.buttonClear).text(), expectedLabel )
+    picker.stop();
+}
 
+test( 'we can change current locale and it updates subsequent time picker calls', function() {
+
+    $DOM.append( $INPUT.clone() )
+    var $input = $DOM.find( 'input' )
+
+    ensureClearButtonLabelIsEqualTo( 'Clear', $input )
+
+    // Now, changing the locale
+    Picker.useTimeLocale("fr_FR")
+
+    ensureClearButtonLabelIsEqualTo( 'Effacer', $input )
+
+    // Falling back to the default EN locale
+    Picker.useTimeLocale("en_US")
+
+    ensureClearButtonLabelIsEqualTo( 'Clear', $input )
+})


### PR DESCRIPTION
Hi,

This PR fixes #792 and allows to define locale and use it at runtime through helper methods `Picker.useDateLocale("fr_FR")` and `Picker.useTimeLocale("fr_FR")`

Starting from the `Picker.use*Locale()` call, pickers will use given locale for labels displayed.

I kept the backward compatibility about the fact that as long as a translation file is provided, this one is automatically applied (see [here](https://github.com/amsul/pickadate.js/commit/8cb06a7ceaffab3b252a89df704a2298273bb9d7#diff-25fe9bec351e11bdd156426b27c9d07dR1091)). 
However, I'm wondering if it wouldn't be better to break this backward compat and ask users to explicitely call the `Picker.use*Locale()` calls at application startup if they want to use only 1 locale on their website.

Because it implies that when the user integrates several translation js files, every of these files are loaded one after the other (and the last loaded one is applied by default, unless the user explicitely calls the `Picker.use*Locale()` function)

Don't hesitate to discuss about the design I used (I wasn't sure defining utility methods on `Picker` was the way to go .. if it isn't, don't hesitate to tell me the location I should put these function and I'll update the PR accordingly)
