### PR TITLE
bind click and focus events when editable

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -626,19 +626,18 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
             val( $ELEMENT.data('value') ?
                 P.get('select', SETTINGS.format) :
                 ELEMENT.value
-            )
+            ).
 
+            // On focus/click, open the picker.
+            on( 'focus.' + STATE.id + ' click.' + STATE.id, function(event) {
+                event.preventDefault()
+                P.open()
+            })
 
         // Only bind keydown events if the element isn’t editable.
         if ( !SETTINGS.editable ) {
 
             $ELEMENT.
-
-                // On focus/click, open the picker.
-                on( 'focus.' + STATE.id + ' click.' + STATE.id, function(event) {
-                    event.preventDefault()
-                    P.open()
-                }).
 
                 // Handle keyboard event based on the picker being opened or not.
                 on( 'keydown.' + STATE.id, handleKeydownEvent )


### PR DESCRIPTION
When the `editable` option is set to true, the picker will not open when clicked. When the picker is editable, keyboard events are not bound to the input element. It looks like binding for click and focus events were moved inside the conditional and are only put in place when the picker is not editable.
