### PR TITLE
Sometimes there is no this, only window.

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -16,6 +16,9 @@
         module.exports = factory( require('jquery') )
 
     // Browser globals.
+    else if ( typeof window == 'object' )
+        window.Picker = factory( jQuery )
+    
     else this.Picker = factory( jQuery )
 
 }(function( $ ) {


### PR DESCRIPTION
Fixes scenarios where the library is called with undefined `this`, yet there is a browser global window object.
