### PR TITLE
Allow npm to find this package easier.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.6",
   "title": "pickadate.js",
   "description": "The mobile-friendly, responsive, and lightweight jQuery date & time input picker.",
+  "main": "lib/picker.js",
   "keywords": [
     "date",
     "time",


### PR DESCRIPTION
require("pickadate")