### PR TITLE
dynamic maximum number of years displayed

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -1094,7 +1094,8 @@ DatePicker.prototype.nodes = function( isOpen ) {
 
             // If years selector is set to a literal "true", set it to 5. Otherwise
             // divide in half to get half before and half after focused year.
-            numberYears = settings.selectYears === true ? 5 : ~~( settings.selectYears / 2 )
+            maxNumberYears = settings.maxYearsSelectable === null ? maxLimitObject.year - minLimitObject.year : settings.maxYearsSelectable,
+            numberYears = settings.selectYears === true ? maxNumberYears : ~~( settings.selectYears / 2 )
 
             // If there are years to select, add a dropdown menu.
             if ( numberYears ) {
@@ -1295,6 +1296,9 @@ DatePicker.defaults = (function( prefix ) {
         clear: 'Clear',
         close: 'Close',
 
+        // Maximum Years selection
+        maxYearsSelectable: 5,
+
         // Picker close behavior
         closeOnSelect: true,
         closeOnClear: true,
@@ -1349,6 +1353,3 @@ Picker.extend( 'pickadate', DatePicker )
 
 
 }));
-
-
-


### PR DESCRIPTION
This will add an option `maxYearsSelectable` that can be set to a fixed
number which will end up in "current year +/- fixed number" or null to
display all years possible. This will fix #844
