### PR TITLE
Remove reference to $root on teardown

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -200,6 +200,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                 // Remove the root.
                 P.$root.remove()
+                P.$root = null;
 
                 // Remove the input class, remove the stored data, and unbind
                 // the events (after a tick for IE - see `P.close`).
@@ -360,14 +361,17 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 $ELEMENT.removeClass( CLASSES.active )
                 aria( ELEMENT, 'expanded', false )
 
+                // Grab the root element so that the timeout has a reference to it
+                var $root = P.$root;
+
                 // * A Firefox bug, when `html` has `overflow:hidden`, results in
                 //   killing transitions :(. So remove the “opened” state on the next tick.
                 //   Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=625289
                 setTimeout( function() {
 
                     // Remove the “opened” and “focused” class from the picker root.
-                    P.$root.removeClass( CLASSES.opened + ' ' + CLASSES.focused )
-                    aria( P.$root[0], 'hidden', true )
+                    $root.removeClass( CLASSES.opened + ' ' + CLASSES.focused )
+                    aria( $root[0], 'hidden', true )
 
                 }, 0 )
 


### PR DESCRIPTION
The setTimeout function needs access to the $root variable even after
teardown. Leaving the reference will leak the $root dom element after
setTimeout runs. Memoize the reference to $root so that timeout can run,
but remove it in the stop() after it calls close().
