### PR TITLE
zh_CN.js file,the last two lines maybe not be required.

### DIFF
--- a/lib/translations/zh_CN.js
+++ b/lib/translations/zh_CN.js
@@ -1,4 +1,4 @@
-// Simplified Chinese
+﻿// Simplified Chinese
 
 jQuery.extend( jQuery.fn.pickadate.defaults, {
     monthsFull: [ '一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月' ],
@@ -11,8 +11,4 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     firstDay: 1,
     format: 'yyyy 年 mm 月 dd 日',
     formatSubmit: 'yyyy/mm/dd'
-});
-
-jQuery.extend( jQuery.fn.pickatime.defaults, {
-    clear: '清除'
 });


### PR DESCRIPTION
  Because I find the 9th line and the last two lines is the same effect.The last two lines is repeated and chrome throw error that last two lines produce.
  I am Chinese and like this plug that use our site very much.I hope to contribute for pickadate.js.Thank you very much.

-delete last two lines in zh_CN.js file.