### PR TITLE
Prevent paint when hidden

### DIFF
--- a/lib/themes/classic.css
+++ b/lib/themes/classic.css
@@ -17,6 +17,12 @@
           user-select: none;
 }
 /**
+ *
+ */
+.picker[aria-hidden="true"] {
+   display: none;
+}
+/**
  * The picker input element.
  */
 .picker__input {


### PR DESCRIPTION
Currently the element "picker__holder" was repainted every scroll, even though it was invisible. I'm not sure why, but this property fixes it (invisible elements should be out of "calculation").