### PR TITLE
January misspelled

### DIFF
--- a/lib/translations/hr_HR.js
+++ b/lib/translations/hr_HR.js
@@ -1,7 +1,7 @@
 // Croatian
 
 jQuery.extend( jQuery.fn.pickadate.defaults, {
-    monthsFull: [ 'sijećanj', 'veljača', 'ožujak', 'travanj', 'svibanj', 'lipanj', 'srpanj', 'kolovoz', 'rujan', 'listopad', 'studeni', 'prosinac' ],
+    monthsFull: [ 'siječanj', 'veljača', 'ožujak', 'travanj', 'svibanj', 'lipanj', 'srpanj', 'kolovoz', 'rujan', 'listopad', 'studeni', 'prosinac' ],
     monthsShort: [ 'sij', 'velj', 'ožu', 'tra', 'svi', 'lip', 'srp', 'kol', 'ruj', 'lis', 'stu', 'pro' ],
     weekdaysFull: [ 'nedjelja', 'ponedjeljak', 'utorak', 'srijeda', 'četvrtak', 'petak', 'subota' ],
     weekdaysShort: [ 'ned', 'pon', 'uto', 'sri', 'čet', 'pet', 'sub' ],


### PR DESCRIPTION
Proof:
https://translate.google.com/#auto/hr/january