### PR TITLE
update Chinese translation

### DIFF
--- a/lib/translations/zh_CN.js
+++ b/lib/translations/zh_CN.js
@@ -5,7 +5,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     monthsShort: [ '一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二' ],
     weekdaysFull: [ '星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六' ],
     weekdaysShort: [ '日', '一', '二', '三', '四', '五', '六' ],
-    today: '今日',
+    today: '今天',
     clear: '清除',
     close: '关闭',
     firstDay: 1,


### PR DESCRIPTION
We usually use "今天" instead of "今日" in Simplified Chinese (although there are no differences between them).