### PR TITLE
Fix year and month select styling

### DIFF
--- a/lib/themes/classic.date.css
+++ b/lib/themes/classic.date.css
@@ -37,7 +37,6 @@
 .picker__select--year {
   border: 1px solid #b7b7b7;
   height: 2em;
-  padding: .5em;
   margin-left: .25em;
   margin-right: .25em;
 }


### PR DESCRIPTION
The padding made the text not fit the height, and being cut off. Removing fixes this issue.