### PR TITLE
Using UTC values prevents a browser specific issue with DST in certain regions

### DIFF
--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -241,9 +241,9 @@ DatePicker.prototype.create = function( type, value, options ) {
     // Return the compiled object.
     return {
         year: isInfiniteValue || value.getFullYear(),
-        month: isInfiniteValue || value.getMonth(),
-        date: isInfiniteValue || value.getDate(),
-        day: isInfiniteValue || value.getDay(),
+        month: isInfiniteValue || value.getUTCMonth(),
+        date: isInfiniteValue || value.getUTCDate(),
+        day: isInfiniteValue || value.getUTCDay(),
         obj: isInfiniteValue || value,
         pick: isInfiniteValue || value.getTime()
     }

--- a/lib/picker.date.js
+++ b/lib/picker.date.js
@@ -245,9 +245,17 @@ DatePicker.prototype.create = function( type, value, options ) {
         date: isInfiniteValue || value.getUTCDate(),
         day: isInfiniteValue || value.getUTCDay(),
         obj: isInfiniteValue || value,
-        pick: isInfiniteValue || value.getTime()
+        pick: isInfiniteValue || this.getUTCTime(value)
     }
 } //DatePicker.prototype.create
+
+/**
+ * Returns the time value of a date object using its UTC values
+ */
+DatePicker.prototype.getUTCTime = function ( value ) {
+    value = new Date( value.getFullYear(), value.getUTCMonth(), value.getUTCDate(), value.getUTCHours(), value.getUTCMinutes(), value.getUTCSeconds() )
+    return value.getTime()
+}
 
 
 /**
@@ -318,7 +326,7 @@ DatePicker.prototype.overlapRanges = function( one, two ) {
 DatePicker.prototype.now = function( type, value, options ) {
     value = new Date()
     if ( options && options.rel ) {
-        value.setDate( value.getDate() + options.rel )
+        value.setDate( value.getUTCDate() + options.rel )
     }
     return this.normalize( value, options )
 }


### PR DESCRIPTION
Using UTC values prevents a browser specific issue where the day immediately following the end or start of DST in certain regions will be displayed as the day before. E.g. The 14th of October will be displayed twice in Firefox in computers whose locale is set to BR.