### PR TITLE
Add fallback for input[type=date] on unsupported browsers

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -92,7 +92,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 ELEMENT.autofocus = ELEMENT == getActiveElement()
                 ELEMENT.readOnly = !SETTINGS.editable
                 ELEMENT.id = ELEMENT.id || STATE.id
-                if ( ELEMENT.type != 'text' ) {
+                if ( $ELEMENT.attr('type') != 'text' ) {
                     ELEMENT.type = 'text'
                 }
 


### PR DESCRIPTION
In case of Mozilla Firefox (in the current version, not beta), and other browsers that don't support input[type=date], ELEMENT.type returns 'text' and thus, the type wouldn't be changed to text.

This pull request changes that behavior so that it works throughout.

To recreate, run on [Mozilla Firefox (version < 57)](https://caniuse.com/#feat=input-datetime) -
`var test = document.createElement('input')`
`test.type='date'`
`test.type`

or on Chrome -
`var test = document.createElement('input')`
`test.type='abc'`
`test.type`