### PR TITLE
Check that pickadate and pickatime exist before merging

### DIFF
--- a/lib/translations/ar.js
+++ b/lib/translations/ar.js
@@ -1,6 +1,6 @@
 // Arabic
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'يناير', 'فبراير', 'مارس', 'ابريل', 'مايو', 'يونيو', 'يوليو', 'اغسطس', 'سبتمبر', 'اكتوبر', 'نوفمبر', 'ديسمبر' ],
     monthsShort: [ 'يناير', 'فبراير', 'مارس', 'ابريل', 'مايو', 'يونيو', 'يوليو', 'اغسطس', 'سبتمبر', 'اكتوبر', 'نوفمبر', 'ديسمبر' ],
     weekdaysFull: [ 'الاحد', 'الاثنين', 'الثلاثاء', 'الاربعاء', 'الخميس', 'الجمعة', 'السبت' ],
@@ -11,6 +11,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'مسح'
 });

--- a/lib/translations/bg_BG.js
+++ b/lib/translations/bg_BG.js
@@ -1,6 +1,6 @@
 // Bulgarian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'януари','февруари','март','април','май','юни','юли','август','септември','октомври','ноември','декември' ],
     monthsShort: [ 'янр','фев','мар','апр','май','юни','юли','авг','сеп','окт','ное','дек' ],
     weekdaysFull: [ 'неделя', 'понеделник', 'вторник', 'сряда', 'четвъртък', 'петък', 'събота' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'изтривам'
 });

--- a/lib/translations/bs_BA.js
+++ b/lib/translations/bs_BA.js
@@ -1,6 +1,6 @@
 // Bosnian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'januar', 'februar', 'mart', 'april', 'maj', 'juni', 'juli', 'august', 'septembar', 'oktobar', 'novembar', 'decembar' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'nedjelja', 'ponedjeljak', 'utorak', 'srijeda', 'cetvrtak', 'petak', 'subota' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'izbrisati'
 });

--- a/lib/translations/ca_ES.js
+++ b/lib/translations/ca_ES.js
@@ -1,6 +1,6 @@
 // Catalan
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Gener', 'Febrer', 'Març', 'Abril', 'Maig', 'juny', 'Juliol', 'Agost', 'Setembre', 'Octubre', 'Novembre', 'Desembre' ],
     monthsShort: [ 'Gen', 'Feb', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Oct', 'Nov', 'Des' ],
     weekdaysFull: [ 'diumenge', 'dilluns', 'dimarts', 'dimecres', 'dijous', 'divendres', 'dissabte' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'esborra'
 });

--- a/lib/translations/cs_CZ.js
+++ b/lib/translations/cs_CZ.js
@@ -1,6 +1,6 @@
 // Czech
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'leden', 'únor', 'březen', 'duben', 'květen', 'červen', 'červenec', 'srpen', 'září', 'říjen', 'listopad', 'prosinec' ],
     monthsShort: [ 'led', 'úno', 'bře', 'dub', 'kvě', 'čer', 'čvc', 'srp', 'zář', 'říj', 'lis', 'pro' ],
     weekdaysFull: [ 'neděle', 'pondělí', 'úterý', 'středa', 'čtvrtek', 'pátek', 'sobota' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     close: 'zavřít'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'vymazat'
 });

--- a/lib/translations/da_DK.js
+++ b/lib/translations/da_DK.js
@@ -1,6 +1,6 @@
 // Danish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'januar', 'februar', 'marts', 'april', 'maj', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'slet'
 });

--- a/lib/translations/de_DE.js
+++ b/lib/translations/de_DE.js
@@ -1,6 +1,6 @@
 // German
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember' ],
     monthsShort: [ 'Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez' ],
     weekdaysFull: [ 'Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag' ],
@@ -13,7 +13,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Löschen',
     format: 'H:i'
 });

--- a/lib/translations/el_GR.js
+++ b/lib/translations/el_GR.js
@@ -1,6 +1,6 @@
 // Greek
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Ιανουάριος', 'Φεβρουάριος', 'Μάρτιος', 'Απρίλιος', 'Μάιος', 'Ιούνιος', 'Ιούλιος', 'Αύγουστος', 'Σεπτέμβριος', 'Οκτώβριος', 'Νοέμβριος', 'Δεκέμβριος' ],
     monthsShort: [ 'Ιαν', 'Φεβ', 'Μαρ', 'Απρ', 'Μαι', 'Ιουν', 'Ιουλ', 'Αυγ', 'Σεπ', 'Οκτ', 'Νοε', 'Δεκ' ],
     weekdaysFull: [ 'Κυριακή', 'Δευτέρα', 'Τρίτη', 'Τετάρτη', 'Πέμπτη', 'Παρασκευή', 'Σάββατο' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Διαγραφή'
 });

--- a/lib/translations/es_ES.js
+++ b/lib/translations/es_ES.js
@@ -1,6 +1,6 @@
 // Spanish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre' ],
     monthsShort: [ 'ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic' ],
     weekdaysFull: [ 'Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Borrar'
 });

--- a/lib/translations/et_EE.js
+++ b/lib/translations/et_EE.js
@@ -1,6 +1,6 @@
 // Estonian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'jaanuar', 'veebruar', 'märts', 'aprill', 'mai', 'juuni', 'juuli', 'august', 'september', 'oktoober', 'november', 'detsember' ],
     monthsShort: [ 'jaan', 'veebr', 'märts', 'apr', 'mai', 'juuni', 'juuli', 'aug', 'sept', 'okt', 'nov', 'dets' ],
     weekdaysFull: [ 'pühapäev', 'esmaspäev', 'teisipäev', 'kolmapäev', 'neljapäev', 'reede', 'laupäev' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'kustuta'
 });

--- a/lib/translations/eu_ES.js
+++ b/lib/translations/eu_ES.js
@@ -1,6 +1,6 @@
 // Basque
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'urtarrila', 'otsaila', 'martxoa', 'apirila', 'maiatza', 'ekaina', 'uztaila', 'abuztua', 'iraila', 'urria', 'azaroa', 'abendua' ],
     monthsShort: [ 'urt', 'ots', 'mar', 'api', 'mai', 'eka', 'uzt', 'abu', 'ira', 'urr', 'aza', 'abe' ],
     weekdaysFull: [ 'igandea', 'astelehena', 'asteartea', 'asteazkena', 'osteguna', 'ostirala', 'larunbata' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'garbitu'
 });

--- a/lib/translations/fa_IR.js
+++ b/lib/translations/fa_IR.js
@@ -1,6 +1,6 @@
 // Farsi
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'ژانویه', 'فوریه', 'مارس', 'آوریل', 'مه', 'ژوئن', 'ژوئیه', 'اوت', 'سپتامبر', 'اکتبر', 'نوامبر', 'دسامبر'],
     monthsShort: [ 'ژانویه', 'فوریه', 'مارس', 'آوریل', 'مه', 'ژوئن', 'ژوئیه', 'اوت', 'سپتامبر', 'اکتبر', 'نوامبر', 'دسامبر' ],
     weekdaysFull: [ 'یکشنبه', 'دوشنبه', 'سه شنبه', 'چهارشنبه', 'پنجشنبه', 'جمعه', 'شنبه' ],
@@ -14,6 +14,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
 	labelMonthPrev: 'ماه قبلی'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'پاک کردن'
 });

--- a/lib/translations/fi_FI.js
+++ b/lib/translations/fi_FI.js
@@ -1,6 +1,6 @@
 // Finnish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'tammikuu', 'helmikuu', 'maaliskuu', 'huhtikuu', 'toukokuu', 'kesäkuu', 'heinäkuu', 'elokuu', 'syyskuu', 'lokakuu', 'marraskuu', 'joulukuu' ],
     monthsShort: [ 'tammi', 'helmi', 'maalis', 'huhti', 'touko', 'kesä', 'heinä', 'elo', 'syys', 'loka', 'marras', 'joulu' ],
     weekdaysFull: [ 'sunnuntai', 'maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'tyhjennä'
 });

--- a/lib/translations/fr_FR.js
+++ b/lib/translations/fr_FR.js
@@ -1,6 +1,6 @@
 // French
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre' ],
     monthsShort: [ 'Jan', 'Fev', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Dec' ],
     weekdaysFull: [ 'Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi' ],
@@ -17,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelYearSelect:"Sélectionner une année"
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Effacer',
     format: 'H:i'
 });

--- a/lib/translations/ge_GEO.js
+++ b/lib/translations/ge_GEO.js
@@ -1,6 +1,6 @@
 // Georgian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'იანვარი', 'თებერვალი', 'მარტი', 'აპრილი', 'მაისი', 'ივნისი', 'ივლისი', 'აგვისტო', 'სექტემბერი', 'ოქტომბერი', 'ნოემბერი', 'დეკემბერი' ],
     monthsShort: [ 'იან', 'თებ', 'მარტ', 'აპრ', 'მაი', 'ივნ', 'ივლ', 'აგვ', 'სექტ', 'ოქტ', 'ნოემ', 'დეკ' ],
     weekdaysFull: [ 'კვირა', 'ორშაბათი', 'სამშაბათი', 'ოთხშაბათი', 'ხუშაბათი', 'პარასკევი', 'შაბათი' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'გასუფთავება'
 });

--- a/lib/translations/gl_ES.js
+++ b/lib/translations/gl_ES.js
@@ -1,6 +1,6 @@
 // Galician
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Xaneiro', 'Febreiro', 'Marzo', 'Abril', 'Maio', 'Xuño', 'Xullo', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Decembro' ],
     monthsShort: [ 'xan', 'feb', 'mar', 'abr', 'mai', 'xun', 'xul', 'ago', 'sep', 'out', 'nov', 'dec' ],
     weekdaysFull: [ 'domingo', 'luns', 'martes', 'mércores', 'xoves', 'venres', 'sábado' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'borrar'
 });

--- a/lib/translations/he_IL.js
+++ b/lib/translations/he_IL.js
@@ -1,6 +1,6 @@
 // Hebrew
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני', 'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר' ],
     monthsShort: [ 'ינו', 'פבר', 'מרץ', 'אפר', 'מאי', 'יונ', 'יול', 'אוג', 'ספט', 'אוק', 'נוב', 'דצמ' ],
     weekdaysFull: [ 'יום ראשון', 'יום שני', 'יום שלישי', 'יום רביעי', 'יום חמישי', 'יום ששי', 'יום שבת' ],
@@ -11,6 +11,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'למחוק'
 });

--- a/lib/translations/hi_IN.js
+++ b/lib/translations/hi_IN.js
@@ -1,4 +1,4 @@
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'जनवरी', 'फरवरी', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अगस्त', 'सितम्बर', 'अक्टूबर', 'नवम्बर', 'दिसम्बर' ],
     monthsShort: [ 'जन', 'फर', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जु', 'अग', 'सित', 'अक्टू', 'नव', 'दिस' ],
     weekdaysFull: [ 'रविवार', 'सोमवार', 'मंगलवार', 'बुधवार', 'गुरुवार', 'शुक्रवार', 'शनिवार' ],
@@ -15,6 +15,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelYearSelect: 'किसि एक वर्ष का चयन करें'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'चुनी हुई तारीख को मिटाएँ'
 });

--- a/lib/translations/hr_HR.js
+++ b/lib/translations/hr_HR.js
@@ -1,6 +1,6 @@
 // Croatian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'siječanj', 'veljača', 'ožujak', 'travanj', 'svibanj', 'lipanj', 'srpanj', 'kolovoz', 'rujan', 'listopad', 'studeni', 'prosinac' ],
     monthsShort: [ 'sij', 'velj', 'ožu', 'tra', 'svi', 'lip', 'srp', 'kol', 'ruj', 'lis', 'stu', 'pro' ],
     weekdaysFull: [ 'nedjelja', 'ponedjeljak', 'utorak', 'srijeda', 'četvrtak', 'petak', 'subota' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Izbriši'
 });

--- a/lib/translations/hu_HU.js
+++ b/lib/translations/hu_HU.js
@@ -1,6 +1,6 @@
 // Hungarian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'január', 'február', 'március', 'április', 'május', 'június', 'július', 'augusztus', 'szeptember', 'október', 'november', 'december' ],
     monthsShort: [ 'jan', 'febr', 'márc', 'ápr', 'máj', 'jún', 'júl', 'aug', 'szept', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'vasárnap', 'hétfő', 'kedd', 'szerda', 'csütörtök', 'péntek', 'szombat' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Törlés'
 });

--- a/lib/translations/id_ID.js
+++ b/lib/translations/id_ID.js
@@ -1,6 +1,6 @@
 // Indonesian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Januari', 'Februari', 'Maret', 'April', 'Mei', 'Juni', 'Juli', 'Agustus', 'September', 'Oktober', 'November', 'Desember' ],
     monthsShort: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Mei', 'Jun', 'Jul', 'Agu', 'Sep', 'Okt', 'Nov', 'Des' ],
     weekdaysFull: [ 'Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'menghapus'
 });

--- a/lib/translations/is_IS.js
+++ b/lib/translations/is_IS.js
@@ -1,6 +1,6 @@
 // Icelandic
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'janúar', 'febrúar', 'mars', 'apríl', 'maí', 'júní', 'júlí', 'ágúst', 'september', 'október', 'nóvember', 'desember' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maí', 'jún', 'júl', 'ágú', 'sep', 'okt', 'nóv', 'des' ],
     weekdaysFull: [ 'sunnudagur', 'mánudagur', 'þriðjudagur', 'miðvikudagur', 'fimmtudagur', 'föstudagur', 'laugardagur' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Hreinsa'
 });

--- a/lib/translations/it_IT.js
+++ b/lib/translations/it_IT.js
@@ -1,6 +1,6 @@
 // Italian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'gennaio', 'febbraio', 'marzo', 'aprile', 'maggio', 'giugno', 'luglio', 'agosto', 'settembre', 'ottobre', 'novembre', 'dicembre' ],
     monthsShort: [ 'gen', 'feb', 'mar', 'apr', 'mag', 'giu', 'lug', 'ago', 'set', 'ott', 'nov', 'dic' ],
     weekdaysFull: [ 'domenica', 'lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato' ],
@@ -17,7 +17,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelYearSelect: 'Seleziona un anno'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Cancella',
     format: 'HH:i',
     formatSubmit: 'HH:i'

--- a/lib/translations/ja_JP.js
+++ b/lib/translations/ja_JP.js
@@ -1,6 +1,6 @@
 // Japanese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ '1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月' ],
     monthsShort: [ '1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月' ],
     weekdaysFull: [ '日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: '消去'
 });

--- a/lib/translations/ko_KR.js
+++ b/lib/translations/ko_KR.js
@@ -1,6 +1,6 @@
 // Korean
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ '1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월' ],
     monthsShort: [ '1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월' ],
     weekdaysFull: [ '일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: '취소'
 });

--- a/lib/translations/lt_LT.js
+++ b/lib/translations/lt_LT.js
@@ -1,6 +1,6 @@
 // Lietuviškai
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     labelMonthNext: 'Sekantis mėnuo',
     labelMonthPrev: 'Ankstesnis mėnuo',
     labelMonthSelect: 'Pasirinkite mėnesį',
@@ -18,7 +18,7 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Išvalyti',
     format: 'HH:i'
 });

--- a/lib/translations/lv_LV.js
+++ b/lib/translations/lv_LV.js
@@ -1,6 +1,6 @@
 // Latvian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Janvāris', 'Februāris', 'Marts', 'Aprīlis', 'Maijs', 'Jūnijs', 'Jūlijs', 'Augusts', 'Septembris', 'Oktobris', 'Novembris', 'Decembris' ],
     monthsShort: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jūn', 'Jūl', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec' ],
     weekdaysFull: [ 'Svētdiena', 'Pirmdiena', 'Otrdiena', 'Trešdiena', 'Ceturtdiena', 'Piektdiena', 'Sestdiena' ],
@@ -17,6 +17,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelYearSelect: 'Izvēlēties gadu'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Dzēst'
 });

--- a/lib/translations/nb_NO.js
+++ b/lib/translations/nb_NO.js
@@ -1,6 +1,6 @@
 // Norwegian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des' ],
     weekdaysFull: [ 'søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'nullstill'
 });

--- a/lib/translations/ne_NP.js
+++ b/lib/translations/ne_NP.js
@@ -1,6 +1,6 @@
 // Nepali
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'जनवरी', 'फेब्रुअरी', 'मार्च', 'अप्रिल', 'मे', 'जुन', 'जुलाई', 'अगस्त', 'सेप्टेम्बर', 'अक्टोबर', 'नोवेम्बर', 'डिसेम्बर' ],
     monthsShort: [ 'जन', 'फेब्रु', 'मार्च', 'अप्रिल', 'मे', 'जुन', 'जुल', 'अग', 'सेप्टे', 'अक्टो', 'नोभे', 'डिसे' ],
     weekdaysFull: [ 'सोमबार', 'मङ्लबार', 'बुधबार', 'बिहीबार', 'शुक्रबार', 'शनिबार', 'आईतबार' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'मेटाउनुहोस्'
 });

--- a/lib/translations/nl_NL.js
+++ b/lib/translations/nl_NL.js
@@ -1,6 +1,6 @@
 // Dutch
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'maa', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'wissen'
 });

--- a/lib/translations/pl_PL.js
+++ b/lib/translations/pl_PL.js
@@ -1,6 +1,6 @@
 // Polish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'styczeń', 'luty', 'marzec', 'kwiecień', 'maj', 'czerwiec', 'lipiec', 'sierpień', 'wrzesień', 'październik', 'listopad', 'grudzień' ],
     monthsShort: [ 'sty', 'lut', 'mar', 'kwi', 'maj', 'cze', 'lip', 'sie', 'wrz', 'paź', 'lis', 'gru' ],
     weekdaysFull: [ 'niedziela', 'poniedziałek', 'wtorek', 'środa', 'czwartek', 'piątek', 'sobota' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'usunąć'
 });

--- a/lib/translations/pt_BR.js
+++ b/lib/translations/pt_BR.js
@@ -1,6 +1,6 @@
 // Brazilian Portuguese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho', 'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro' ],
     monthsShort: [ 'jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez' ],
     weekdaysFull: [ 'domingo', 'segunda-feira', 'terça-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sábado' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'limpar'
 });

--- a/lib/translations/pt_PT.js
+++ b/lib/translations/pt_PT.js
@@ -1,6 +1,6 @@
 // Portuguese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro' ],
     monthsShort: [ 'jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez' ],
     weekdaysFull: [ 'Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Limpar'
 });

--- a/lib/translations/ro_RO.js
+++ b/lib/translations/ro_RO.js
@@ -1,6 +1,6 @@
 // Romanian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'ianuarie', 'februarie', 'martie', 'aprilie', 'mai', 'iunie', 'iulie', 'august', 'septembrie', 'octombrie', 'noiembrie', 'decembrie' ],
     monthsShort: [ 'ian', 'feb', 'mar', 'apr', 'mai', 'iun', 'iul', 'aug', 'sep', 'oct', 'noi', 'dec' ],
     weekdaysFull: [ 'duminică', 'luni', 'marţi', 'miercuri', 'joi', 'vineri', 'sâmbătă' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'șterge'
 });

--- a/lib/translations/ru_RU.js
+++ b/lib/translations/ru_RU.js
@@ -1,6 +1,6 @@
 // Russian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'января', 'февраля', 'марта', 'апреля', 'мая', 'июня', 'июля', 'августа', 'сентября', 'октября', 'ноября', 'декабря' ],
     monthsShort: [ 'янв', 'фев', 'мар', 'апр', 'май', 'июн', 'июл', 'авг', 'сен', 'окт', 'ноя', 'дек' ],
     weekdaysFull: [ 'воскресенье', 'понедельник', 'вторник', 'среда', 'четверг', 'пятница', 'суббота' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'удалить'
 });

--- a/lib/translations/sk_SK.js
+++ b/lib/translations/sk_SK.js
@@ -1,6 +1,6 @@
 // Slovak
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'január', 'február', 'marec', 'apríl', 'máj', 'jún', 'júl', 'august', 'september', 'október', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'máj', 'jún', 'júl', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'nedeľa', 'pondelok', 'utorok', 'streda', 'štvrtok', 'piatok', 'sobota' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'vymazať'
 });

--- a/lib/translations/sl_SI.js
+++ b/lib/translations/sl_SI.js
@@ -1,6 +1,6 @@
 // Slovenian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'januar', 'februar', 'marec', 'april', 'maj', 'junij', 'julij', 'avgust', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'avg', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'nedelja', 'ponedeljek', 'torek', 'sreda', 'četrtek', 'petek', 'sobota' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'izbriši'
 });

--- a/lib/translations/sv_SE.js
+++ b/lib/translations/sv_SE.js
@@ -1,6 +1,6 @@
 // Swedish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'januari', 'februari', 'mars', 'april', 'maj', 'juni', 'juli', 'augusti', 'september', 'oktober', 'november', 'december' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'maj', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec' ],
     weekdaysFull: [ 'söndag', 'måndag', 'tisdag', 'onsdag', 'torsdag', 'fredag', 'lördag' ],
@@ -17,6 +17,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     labelYearSelect: 'Välj år'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Rensa'
 });

--- a/lib/translations/th_TH.js
+++ b/lib/translations/th_TH.js
@@ -1,6 +1,6 @@
 // Thai
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน', 'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม' ],
     monthsShort: [ 'ม.ค.', 'ก.พ.', 'มี.ค.', 'เม.ย.', 'พ.ค.', 'มิ.ย.', 'ก.ค.', 'ส.ค.', 'ก.ย.', 'ต.ค.', 'พ.ย.', 'ธ.ค.' ],
     weekdaysFull: [ 'อาทติย', 'จันทร', 'องัคาร', 'พุธ', 'พฤหสั บดี', 'ศกุร', 'เสาร' ],
@@ -11,6 +11,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'ลบ'
 });

--- a/lib/translations/tr_TR.js
+++ b/lib/translations/tr_TR.js
@@ -1,6 +1,6 @@
 // Turkish
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran', 'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık' ],
     monthsShort: [ 'Oca', 'Şub', 'Mar', 'Nis', 'May', 'Haz', 'Tem', 'Ağu', 'Eyl', 'Eki', 'Kas', 'Ara' ],
     weekdaysFull: [ 'Pazar', 'Pazartesi', 'Salı', 'Çarşamba', 'Perşembe', 'Cuma', 'Cumartesi' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'sil'
 });

--- a/lib/translations/uk_UA.js
+++ b/lib/translations/uk_UA.js
@@ -1,6 +1,6 @@
 // Ukrainian
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'січень', 'лютий', 'березень', 'квітень', 'травень', 'червень', 'липень', 'серпень', 'вересень', 'жовтень', 'листопад', 'грудень' ],
     monthsShort: [ 'січ', 'лют', 'бер', 'кві', 'тра', 'чер', 'лип', 'сер', 'вер', 'жов', 'лис', 'гру' ],
     weekdaysFull: [ 'неділя', 'понеділок', 'вівторок', 'середа', 'четвер', 'п‘ятниця', 'субота' ],
@@ -12,6 +12,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'викреслити'
 });

--- a/lib/translations/vi_VN.js
+++ b/lib/translations/vi_VN.js
@@ -1,6 +1,6 @@
 // Vietnamese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ 'Tháng Một', 'Tháng Hai', 'Tháng Ba', 'Tháng Tư', 'Tháng Năm', 'Tháng Sáu', 'Tháng Bảy', 'Tháng Tám', 'Tháng Chín', 'Tháng Mười', 'Tháng Mười Một', 'Tháng Mười Hai' ],
     monthsShort: [ 'Một', 'Hai', 'Ba', 'Tư', 'Năm', 'Sáu', 'Bảy', 'Tám', 'Chín', 'Mười', 'Mười Một', 'Mười Hai' ],
     weekdaysFull: [ 'Chủ Nhật', 'Thứ Hai', 'Thứ Ba', 'Thứ Tư', 'Thứ Năm', 'Thứ Sáu', 'Thứ Bảy' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: 'Xoá'
 });

--- a/lib/translations/zh_CN.js
+++ b/lib/translations/zh_CN.js
@@ -1,6 +1,6 @@
 // Simplified Chinese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ '一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月' ],
     monthsShort: [ '一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二' ],
     weekdaysFull: [ '星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: '清除'
 });

--- a/lib/translations/zh_TW.js
+++ b/lib/translations/zh_TW.js
@@ -1,6 +1,6 @@
 // Traditional Chinese
 
-jQuery.extend( jQuery.fn.pickadate.defaults, {
+jQuery.extend( jQuery.fn.pickadate && jQuery.fn.pickadate.defaults, {
     monthsFull: [ '一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月' ],
     monthsShort: [ '一', '二', '三', '四', '五', '六', '七', '八', '九', '十', '十一', '十二' ],
     weekdaysFull: [ '星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六' ],
@@ -13,6 +13,6 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd'
 });
 
-jQuery.extend( jQuery.fn.pickatime.defaults, {
+jQuery.extend( jQuery.fn.pickatime && jQuery.fn.pickatime.defaults, {
     clear: '清除'
 });


### PR DESCRIPTION
Loading a translation file could cause js errors in the case that you have not loaded __both__ picker.date.js and picker.time.js. It should not be necessary to load a time picker if you only need a date picker and vice versa. By checking first, it is now safe to load a translation even if you are using only one or the other. 