### PR TITLE
fixes #1074 activeElement is breaking $.contains() method

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -726,7 +726,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     // * For IE, non-focusable elements can be active elements as well
                     //   (http://stackoverflow.com/a/2684561).
                     activeElement = getActiveElement()
-                    activeElement = activeElement && ( activeElement.type || activeElement.href )
+                    activeElement = activeElement && ( (activeElement.type || activeElement.href ) ? activeElement : null);
 
                 // If it’s disabled or nothing inside is actively focused, re-focus the element.
                 if ( targetDisabled || activeElement && !$.contains( P.$root[0], activeElement ) ) {


### PR DESCRIPTION
fixes #1074 for activeElement is breaking $.contains() method for lower version of jQuery 1.7 but it works well with jQuery 2.1.3.

[https://codepen.io/amitesh/pen/PRLwvQ](Sample code on CodePen)