### PR TITLE
Added .today() method

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -400,6 +400,14 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
             clear: function( options ) {
                 return P.set( 'clear', null, options )
             }, //clear
+            
+            
+            /**
+             * Sets calendar view to current day
+             */
+            today: function() {
+                return P.set( 'view', new Date() )
+            }, //today
 
 
             /**

--- a/tests/units/date.js
+++ b/tests/units/date.js
@@ -200,6 +200,28 @@ test( '`clear`', function() {
     strictEqual( picker.get('select'), null, 'Clears out selection' )
 })
 
+test( '`today`', function() {
+
+    var picker = this.picker
+    var dateToday = new Date()
+    
+    dateToday.setHours(0,0,0,0)
+    dateToday.setDate(1)
+    
+    var dateYearAgo = new Date(dateToday.valueOf())
+    
+    dateYearAgo = new Date(dateYearAgo.setFullYear(new Date().getFullYear() - 1))
+    dateYearAgo.setHours(0,0,0,0)
+
+    strictEqual( picker.get('select'), null, 'Starts off without a selection' )
+    
+    picker.set('select', dateYearAgo)
+    strictEqual( picker.get('view').obj.toString(), dateYearAgo.toString(), 'Set date to last year' )
+    
+    picker.today()
+    notStrictEqual( picker.get('view').obj, dateToday, 'Today date is back' )
+})
+
 test( '`select`', function() {
 
     var picker = this.picker,


### PR DESCRIPTION
### TLDR:
Added **.today()** method that resets calendar view to a current date;

### Full story:
When using this plugin on a website with multiple calendars, there was a problem - when really old date was picked, the rest calendars remembered it. So it was needed to change the year and month manually. Of course, there is a TODAY button, but users expected a fresh new calendar and submitted forms with wrong dates.
The plugin missed the functionality to reset calendar view only (without removing picked date from input field). To avoid confusion, I named the method **.today()**, as it don't alter the date field.
Also, added a test case,.