### PR TITLE
Use body instead of html to block overflow

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -254,7 +254,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                     // Prevent the page from scrolling.
                     if ( IS_DEFAULT_THEME ) {
-                        $html.
+                        $('body').
                             css( 'overflow', 'hidden' ).
                             css( 'padding-right', '+=' + getScrollbarWidth() )
                     }
@@ -381,7 +381,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                 // Allow the page to scroll.
                 if ( IS_DEFAULT_THEME ) {
-                    $html.
+                    $('body').
                         css( 'overflow', '' ).
                         css( 'padding-right', '-=' + getScrollbarWidth() )
                 }


### PR DESCRIPTION
In my case (and others have had trouble with this), setting `html`'s `overflow: hidden` causes the page to scroll to the top. I'm using a custom container for the picker (a child of the `body` tag).

Setting `overflow: hidden` on the body tag instead prevents the scrolling.

Closes #769

Once this is merged, would we be able to get another version release? :)