### PR TITLE
Test scroll

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -23,6 +23,7 @@
 var $window = $( window )
 var $document = $( document )
 var $html = $( document.documentElement )
+var $body = $('body')
 var supportsTransitions = document.documentElement.style.transition != null
 
 
@@ -254,7 +255,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                     // Prevent the page from scrolling.
                     if ( IS_DEFAULT_THEME ) {
-                        $('body').
+                        $body.
                             css( 'overflow', 'hidden' ).
                             css( 'padding-right', '+=' + getScrollbarWidth() )
                     }
@@ -381,7 +382,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                 // Allow the page to scroll.
                 if ( IS_DEFAULT_THEME ) {
-                    $('body').
+                    $body.
                         css( 'overflow', '' ).
                         css( 'padding-right', '-=' + getScrollbarWidth() )
                 }

--- a/tests/units/all.htm
+++ b/tests/units/all.htm
@@ -3,10 +3,14 @@
 <meta charset="utf-8">
 <title>pickadate.js &#8226; QUnit testing</title>
 <link rel="stylesheet" href="../../node_modules/qunitjs/qunit/qunit.css">
-
 <body>
 
     <div id="qunit"></div>
+
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+
     <div id="qunit-fixture"></div>
 
     <script src="../../node_modules/jquery/dist/jquery.js"></script>

--- a/tests/units/base.js
+++ b/tests/units/base.js
@@ -452,6 +452,37 @@ test( 'Open and close', function() {
 
 
 
+module( 'Overflow hidden', {
+    setup: function() {
+        $DOM.append( $INPUT.clone() )
+        var $input = $DOM.find( 'input' ).pickadate()
+        this.picker = $input.pickadate( 'picker' )
+        $('html, body').css('height', '100%')
+        $('body').css('overflow', 'hidden')
+    },
+    teardown: function() {
+        $('body').css('overflow', '')
+        $('html, body').css('height', '')
+        this.picker.stop()
+        $DOM.empty()
+    }
+})
+
+test( 'Picker does not change the window scrollY', function() {
+    var picker = this.picker
+
+    window.scrollTo(0,500)
+
+    picker.open()
+    picker.close()
+    strictEqual( window.scrollY, 500, 'Kept scrollY untouched' )
+})
+
+
+
+
+
+
 module( 'Base keyboard events', {
     setup: function() {
         $DOM.append( $INPUT.clone() )


### PR DESCRIPTION
Tests #1117

The test passes, but it passes even if we set `overflow: hidden` on the `html` tag instead. The issue has to do with setting `height: 100%` on `html, body`, then setting `overflow: hidden` on `html, body`. Seems to only happen in Chrome as far as I could test. The unit tests don't also seem to include the default css files so maybe the modal code fork isn't even running? `IS_DEFAULT_THEME` might be false.

Anyway, this is a start. At least it confirms the behaviour that we want.