### PR TITLE
Use fixed Positioning

### DIFF
--- a/lib/themes/default.css
+++ b/lib/themes/default.css
@@ -9,7 +9,7 @@
   text-align: left;
   line-height: 1.2;
   color: #000000;
-  position: absolute;
+  position: fixed;
   z-index: 10000;
   -webkit-user-select: none;
      -moz-user-select: none;


### PR DESCRIPTION
Use fixed positioning to avoid the clipping that is seen when the picker modal is generated inside an element with position relative & overflow set to scroll or hidden.