### PR TITLE
Add this.blur() to stop flash of keyboard on iOS

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -632,6 +632,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
             on( 'focus.' + STATE.id + ' click.' + STATE.id, function(event) {
                 event.preventDefault()
                 P.open()
+                this.blur()
             })
 
         // Only bind keydown events if the element isn’t editable.


### PR DESCRIPTION
Add this.blur() to stop flash of keyboard on iOS

Fixes #1133