### PR TITLE
Add mousedown/up tracking to allow for change in behaviour in Chrome 73

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -41,7 +41,8 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
         // The state of the picker.
         STATE = {
-            id: ELEMENT.id || 'P' + Math.abs( ~~(Math.random() * new Date()) )
+            id: ELEMENT.id || 'P' + Math.abs( ~~(Math.random() * new Date()) ),
+            handlingOpen: false,
         },
 
 
@@ -264,6 +265,17 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                     // Bind the document events.
                     $document.on( 'click.' + STATE.id + ' focusin.' + STATE.id, function( event ) {
+                        // If the picker is currently midway through processing
+                        // the opening sequence of events then don't handle clicks
+                        // on any part of the DOM. This is caused by a bug in Chrome 73
+                        // where a click event is being generated with the incorrect
+                        // path in it.
+                        // In short, if someone does a click that finishes after the
+                        // new element is created then the path contains only the
+                        // parent element and not the input element itself.
+                        if (STATE.handlingOpen) {
+                          return;
+                        }
 
                         var target = getRealEventTarget( event, ELEMENT )
 
@@ -632,6 +644,23 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 event.preventDefault()
                 P.open()
             }, 100))
+
+            // Mousedown handler to capture when the user starts interacting
+            // with the picker. This is used in working around a bug in Chrome 73.
+            .on('mousedown', function() {
+              STATE.handlingOpen = true;
+              var handler = function() {
+                // By default mouseup events are fired before a click event.
+                // By using a timeout we can force the mouseup to be handled
+                // after the corresponding click event is handled.
+                setTimeout(function() {
+                  $(document).off('mouseup', handler);
+                  STATE.handlingOpen = false;
+                }, 0);
+              };
+              $(document).on('mouseup', handler);
+            });
+
 
         // Only bind keydown events if the element isn’t editable.
         if ( !SETTINGS.editable ) {

--- a/tests/units/base.js
+++ b/tests/units/base.js
@@ -457,7 +457,40 @@ asyncTest( 'Open and close', function() {
     }, 200)
 })
 
+asyncTest( 'Open with a slower click', function() {
+    // This test ensures that behaviour in chrome as described in PR 1145
+    // https://github.com/amsul/pickadate.js/pull/1145
+    // is handled correctly
 
+    var picker = this.picker
+
+    // The sequence of events fired by chrome are:
+    //  - focus on the input
+    //  - mousedown on the input
+    //  - mouseup on the input
+    //  - click on the common ancestor (in this case $DOM)
+    picker.$node.focus()
+    setTimeout(function () {
+        ok(picker.get('open') === true, 'Opened due to focus change')
+        picker.$node.trigger({
+            type: 'mousedown'
+        })
+        setTimeout(function () {
+            ok(picker.get('open') === true, 'Still open after mousedown')
+            // The mouseup and the click happen one after the other with no pause
+            picker.$node.trigger({
+                type: 'mouseup'
+            })
+            $DOM.trigger({
+                type: 'click'
+            })
+            setTimeout(function () {
+                ok(picker.get('open') === true, 'Still open after final click event')
+                QUnit.start();
+            }, 200)
+        }, 200)
+    }, 200)
+})
 
 
 


### PR DESCRIPTION
Chrome 73 changes the behaviour of click events when the mousedown is on one element
and the mouseup is on another. The previous behaviour was to not emit any click event
at all. The new behaviour is to emit a click event with the target being the
common ancestor of the elements involved.

In the case of pickadate the calendar is popped up over the input element
meaning that the mousedown event targest the input but the mouseup targest
the calendar itself. This results in the click event targetting the common
ancestor which is not particularly useful.

The workaround here is to track the mousedown and mouseup events during
calendar opening and ignore any click events generated during this.

See https://bugs.chromium.org/p/chromium/issues/detail?id=946459&can=2&q=click
for additional details.

A minimal codepen demonstrating the issue in Chrome is available here
https://codepen.io/mortah/pen/oVRVxa

This manifests itself in pickadate as the picker opening and shutting really quickly. If you want to
replicate it reliably then you need to hold the mouse down slightly before releasing. You can do this
on the demo page for pickadate (https://amsul.ca/pickadate.js/)