### PR TITLE
Reset the styles of the user agent stylesheet for buttons

### DIFF
--- a/lib/apis/dom/index.css
+++ b/lib/apis/dom/index.css
@@ -69,6 +69,9 @@ button.pickadate--element {
   padding: 0;
   justify-content: center;
   align-items: center;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
 }
 .pickadate--button__previous,
 .pickadate--button__today,


### PR DESCRIPTION
Currently in Chrome on Windows we can see the default background color of the buttons.
This PR fixes this by resetting the `background` and `appearance`.

before
![amsul ca_pickadate js_v5_](https://user-images.githubusercontent.com/827205/60367439-825e6000-99ee-11e9-9965-e9a0b3057e92.png)

after
![amsul ca_pickadate js_v5_ (1)](https://user-images.githubusercontent.com/827205/60367441-84c0ba00-99ee-11e9-8e49-bc2acf182e15.png)
