### PR TITLE
Typo and spellings in Indian translation

### DIFF
--- a/lib/translations/hi_IN.js
+++ b/lib/translations/hi_IN.js
@@ -1,9 +1,9 @@
 jQuery.extend( jQuery.fn.pickadate.defaults, {
-    monthsFull: [ 'जनवरी', 'फरवरी', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अगस्त', 'सितम्बर', 'अक्टूबर', 'नवम्बर', 'दिसम्बर' ],
+    monthsFull: [ 'जनवरी', 'फ़रवरी', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अगस्त', 'सितम्बर', 'अक्टूबर', 'नवम्बर', 'दिसम्बर' ],
     monthsShort: [ 'जन', 'फर', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जु', 'अग', 'सित', 'अक्टू', 'नव', 'दिस' ],
     weekdaysFull: [ 'रविवार', 'सोमवार', 'मंगलवार', 'बुधवार', 'गुरुवार', 'शुक्रवार', 'शनिवार' ],
     weekdaysShort: [ 'रवि', 'सोम', 'मंगल', 'बुध', 'गुरु', 'शुक्र','शनि' ],
-    today: 'आज की तारीख चयन करें',
+    today: 'आज की तारीख का चयन करें',
     clear: 'चुनी हुई तारीख को मिटाएँ',
     close: 'विंडो बंद करे',
     firstDay: 1,
@@ -11,8 +11,8 @@ jQuery.extend( jQuery.fn.pickadate.defaults, {
     formatSubmit: 'yyyy/mm/dd',
     labelMonthNext: 'अगले माह का चयन करें',
     labelMonthPrev: 'पिछले माह का चयन करें',
-    labelMonthSelect: 'किसि एक महीने का चयन करें',
-    labelYearSelect: 'किसि एक वर्ष का चयन करें'
+    labelMonthSelect: 'किसी एक महीने का चयन करें',
+    labelYearSelect: 'किसी एक वर्ष का चयन करें'
 });
 
 jQuery.extend( jQuery.fn.pickatime.defaults, {


### PR DESCRIPTION
1. Corrected spelling of ' फ़रवरी ' (notice the dot on the first alphabet)
2. Corrected spelling of  ' किसी '
3. Fixed typo, added ' का ' in today property.