### PR TITLE
Removed setTimeOut in stop method

### DIFF
--- a/lib/picker.js
+++ b/lib/picker.js
@@ -207,9 +207,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 // Remove the input class, remove the stored data, and unbind
                 // the events (after a tick for IE - see `P.close`).
                 $ELEMENT.removeClass( CLASSES.input ).removeData( NAME )
-                setTimeout( function() {
-                    $ELEMENT.off( '.' + STATE.id )
-                }, 0)
+                $ELEMENT.off( '.' + STATE.id )
 
                 // Restore the element state
                 ELEMENT.type = STATE.type


### PR DESCRIPTION
setTimeOut for unbinding in stop method has been removed, due to the fact it was provoking errors when trying to reinitialize the datepicker. Re-initialize is to call the method stop() and then start() or datepicker. The result was having the datepicker initialized but nothing happened when clicking on it (because the events were unbinding by the previous close call)